### PR TITLE
Fix for patchsets with same names in substages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,8 +42,9 @@ EOF
 				rm -rf *-pc
 			fi
 			QUILT_PATCHES=${SUB_STAGE_DIR}/${i}-patches
-			mkdir -p ${i}-pc
-			ln -sf ${i}-pc .pc
+			SUB_STAGE_QUILT_PATCH_DIR="$(basename $SUB_STAGE_DIR)-pc"
+			mkdir -p $SUB_STAGE_QUILT_PATCH_DIR
+			ln -snf $SUB_STAGE_QUILT_PATCH_DIR .pc
 			if [ -e ${SUB_STAGE_DIR}/${i}-patches/EDIT ]; then
 				echo "Dropping into bash to edit patches..."
 				bash


### PR DESCRIPTION
I used the provided *build.sh* script to generate a raspbian-lite image and came across an issue with network configuration.

If ```CLEAN``` variable is not set, image is not generated right. 

In that case (i.e. stage2/01-sys-tweaks and stage2/02-net-tweaks) a
directory with a same name (00-pc) is getting created for both quilt
patch sets. This might yield a situation when second patch set is not
applied.

The fix is to come up with a more sophisticated naming convention for intermediate
patchset directory (which .pc symlinks to) and create separate
directories for each patchset.