### PR TITLE
Minor README.md updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 #TODO
 
-1. Image export
-1. NOOBS export
 1. Simplify running a single stage
 1. Documentation
 

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 
 #Dependencies
 
-`quilt kpartx realpath qemu-user-static debootstrap zerofree`
+`quilt kpartx realpath qemu-user-static debootstrap zerofree pxz`


### PR DESCRIPTION
Removed TODO items for exporting image/NOOBS as they're done now, and added pxz to the list of requirements for the latter.

Willing to write some of the documentation to fill out README.md a bit as I learn how this tool works a bit more as I become more comfortable using pi-gen. This tool is a godsend for Raspple II which has been modifying the Raspbian NOOBS image after the fact with a manual process, so an automated tool we can alter and track changes will make our lives much easier.  ...Now if we could do the same for i686/amd64 Debian!  ;)