### PR TITLE
README.md: Working toward basic documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ use a different `IMG_NAME` to avoid confusion.
 
 You can also define `APT_PROXY` here if you need to.
 
-#Stages
+#Stage Anatomy
+
+
+
+#Raspbian Stages
 
 The build of Raspbian is divided up into several stages for logical clarity
 and modularity.  This causes some initial complexity, but it simplifies

--- a/README.md
+++ b/README.md
@@ -9,25 +9,26 @@
 
 #Config
 
-Environment and other variables may be provided in a file named `config` in
-your current working directory when you run `build.sh`.  At the moment, the
-only thing you must configure is the name of the image to create.  Something
-like this is used for Raspbian:
+Upon execution, `build.sh` will source the file `config` in the current
+working directory.  This bash shell fragment is intended to set needed
+environment variables.
+
+The following environment variables are supported:
+
+ * `IMG_NAME`, the name of the distribution to build (required)
+ * `APT_PROXY`, proxy/cache URL to be included in the build
+
+A simple example for building Raspbian:
 
 ```bash
 IMG_NAME='Raspbian'
 ```
 
-Obviously if you are making changes to the pi-gen stages you should probably
-use a different `IMG_NAME` to avoid confusion.
-
-You can also define `APT_PROXY` here if you need to.
-
 #Stage Anatomy
 
 
 
-#Raspbian Stages
+#Raspbian Stage Overview
 
 The build of Raspbian is divided up into several stages for logical clarity
 and modularity.  This causes some initial complexity, but it simplifies

--- a/README.md
+++ b/README.md
@@ -22,3 +22,49 @@ Obviously if you are making changes to the pi-gen stages you should probably
 use a different `IMG_NAME` to avoid confusion.
 
 You can also define `APT_PROXY` here if you need to.
+
+#Stages
+
+The build of Raspbian is divided up into several stages for logical clarity
+and modularity.  This causes some initial complexity, but it simplifies
+maintenance and allows for more easy customization.
+
+ - Stage 0, bootstrap.  The primary purpose of this stage is to create a
+   usable filesystem.  This is accomplished largely through the use of
+   `debootstrap`, which creates a minimal filesystem suitable for use as a
+   base.tgz on Debian systems.  This stage also configures apt settings and
+   installs `raspberrypi-bootloader` which is missed by debootstrap.  The
+   minimal core is installed but not configured, and the system will not quite
+   boot yet.
+
+ - Stage 1, truly minimal system.  This stage makes the system bootable by
+   installing system files like `/etc/fstab`, configures the bootloader, makes
+   the network operable, and installs packages like raspi-config.  At this
+   stage the system should boot to a local console from which you have the
+   means to perform basic tasks needed to configure and install the system.
+   This is as minimal as a system can possibly get, and its arguably not
+   really usable yet in a traditional sense yet.  Still, if you want minimal,
+   this is minimal and the rest you could reasonably do yourself as sysadmin.
+
+ - State 2, lite system.  This stage produces the Raspbian-Lite image.  It
+   installs some optimized memory functions, sets timezone and charmap
+   defaults, installs fake-hwclock and ntp, wifi and bluetooth support,
+   dphys-swapfile, and other basics for managing the hardware.  It also
+   creates necessary groups and gives the pi user access to sudo and the
+   standard console hardware permission groups.
+
+   There are a few tools that may not make a whole lot of sense here for
+   development purposes on a minimal system such as basic python and lua
+   packages as well as the `build-essential` package.  They are lumped right
+   in with more essential packages presently, though they need not be with
+   pi-gen.  These are understandable for Raspbian's target audience, but if
+   you were looking for something between truly minimal and Raspbian-lite,
+   here's where you start trimming.
+
+ - Stage 3, desktop system.  Here's where you get the full desktop system
+   with X11 and LXDE, web browsers, git for development, Raspbian custom UI
+   enhancements, etc.  This is a base desktop system, with some development
+   tools installed.
+
+ - Stage 4, complete Raspbian system.  More development tools, large packages
+   like LibreOffice, email, sonic-pi, wolfram-engine, etc.  All the things.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,19 @@
 #Dependencies
 
 `quilt kpartx realpath qemu-user-static debootstrap zerofree pxz`
+
+#Config
+
+Environment and other variables may be provided in a file named `config` in
+your current working directory when you run `build.sh`.  At the moment, the
+only thing you must configure is the name of the image to create.  Something
+like this is used for Raspbian:
+
+```bash
+IMG_NAME='Raspbian'
+```
+
+Obviously if you are making changes to the pi-gen stages you should probably
+use a different `IMG_NAME` to avoid confusion.
+
+You can also define `APT_PROXY` here if you need to.


### PR DESCRIPTION
Documented the config file for IMG_NAME and APT_PROXY (the latter sparsely), and described the existing stages used to build Raspbian as they are now.  The latter is somewhat superfluous to pi-gen itself, but the big picture view of generating Raspbian makes the RTFS job for figuring out how stages work an easy task.

Stage anatomy will follow soonish.