### PR TITLE
build.sh: Support comments in package files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,8 @@ EOF
 		fi
 		if [ -f ${i}-packages-nr ]; then
 			log "Begin ${SUB_STAGE_DIR}/${i}-packages-nr"
-			PACKAGES=`cat $i-packages-nr | tr '\n' ' '`
+			PACKAGES="$(sed -e ':a;N;$ !b a' -e 's/[[:space:]]*\(#[^\n]*\)*[[:space:]]/ /g' < ${i}-packages-nr)"
+
 			if [ -n "$PACKAGES" ]; then
 				on_chroot sh -e - << EOF
 apt-get install --no-install-recommends -y $PACKAGES
@@ -26,7 +27,7 @@ EOF
 		fi
 		if [ -f ${i}-packages ]; then
 			log "Begin ${SUB_STAGE_DIR}/${i}-packages"
-			PACKAGES=`cat $i-packages | tr '\n' ' '`
+			PACKAGES="$(sed -e ':a;N;$ !b a' -e 's/[[:space:]]*\(#[^\n]*\)*[[:space:]]/ /g' < ${i}-packages)"
 			if [ -n "$PACKAGES" ]; then
 				on_chroot sh -e - << EOF
 apt-get install -y $PACKAGES

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,6 @@ EOF
 		if [ -f ${i}-packages-nr ]; then
 			log "Begin ${SUB_STAGE_DIR}/${i}-packages-nr"
 			PACKAGES="$(sed -e ':a;N;$ !b a' -e 's/[[:space:]]*\(#[^\n]*\)*[[:space:]]/ /g' < ${i}-packages-nr)"
-
 			if [ -n "$PACKAGES" ]; then
 				on_chroot sh -e - << EOF
 apt-get install --no-install-recommends -y $PACKAGES

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,8 @@ EOF
 		fi
 		if [ -f ${i}-packages-nr ]; then
 			log "Begin ${SUB_STAGE_DIR}/${i}-packages-nr"
-			PACKAGES="$(sed -e ':a;N;$ !b a' -e 's/[[:space:]]*\(#[^\n]*\)*[[:space:]]/ /g' < ${i}-packages-nr)"
+			PACKAGES="$(sed -f "${SCRIPT_DIR}/remove-comments.sed" < ${i}-packages-nr)"
+			PACKAGES="$(sed -e "$sed_expr_packages" < ${i}-packages-nr)"
 			if [ -n "$PACKAGES" ]; then
 				on_chroot sh -e - << EOF
 apt-get install --no-install-recommends -y $PACKAGES
@@ -26,7 +27,7 @@ EOF
 		fi
 		if [ -f ${i}-packages ]; then
 			log "Begin ${SUB_STAGE_DIR}/${i}-packages"
-			PACKAGES="$(sed -e ':a;N;$ !b a' -e 's/[[:space:]]*\(#[^\n]*\)*[[:space:]]/ /g' < ${i}-packages)"
+			PACKAGES="$(sed -f "${SCRIPT_DIR}/remove-comments.sed" < ${i}-packages)"
 			if [ -n "$PACKAGES" ]; then
 				on_chroot sh -e - << EOF
 apt-get install -y $PACKAGES
@@ -76,6 +77,7 @@ EOF
 	popd > /dev/null
 	log "End ${SUB_STAGE_DIR}"
 }
+
 
 run_stage(){
 	log "Begin ${STAGE_DIR}"

--- a/scripts/remove-comments.sed
+++ b/scripts/remove-comments.sed
@@ -1,0 +1,11 @@
+# Deletes comments and collapses whitespace in ##-packages files
+
+# Append (N)ext line to buffer
+# if (!)not ($)buffer is EOF, (b)ranch to (:)label loop
+:loop
+N
+$ !b loop
+
+# Buffer is "line1\nline2\n...lineN", del comments and collapse whitespace
+s/#[^\n]*//g
+s/[[:space:]]\{1,\}/ /g


### PR DESCRIPTION
This patch allows the use of hash comments inside patch files.  It's a
little ugly, but it strips comments and collapses all whitespace down to
single space characters between package names.  It handles comments
anywhere in a line, as well.

Was unsure if \ continuation of the long sed line or the inclusion of a
couple of lines of comments explaining what the sed expressions are
doing would be appreciated, so didn't include them in this patch.