### PR TITLE
rsync single file system

### DIFF
--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -45,4 +45,4 @@ mount -v $ROOT_DEV ${ROOTFS_DIR} -t ext4
 mkdir -p ${ROOTFS_DIR}/boot
 mount -v $BOOT_DEV ${ROOTFS_DIR}/boot -t vfat
 
-rsync ${EXPORT_ROOTFS_DIR}/ ${ROOTFS_DIR}/ -aHAX
+rsync -aHAXx ${EXPORT_ROOTFS_DIR}/ ${ROOTFS_DIR}/

--- a/scripts/common
+++ b/scripts/common
@@ -27,7 +27,7 @@ copy_previous(){
 		false
 	fi
 	mkdir -p ${ROOTFS_DIR}
-	rsync -aHAX ${PREV_ROOTFS_DIR}/ ${ROOTFS_DIR}/
+	rsync -aHAXx ${PREV_ROOTFS_DIR}/ ${ROOTFS_DIR}/
 }
 export -f copy_previous
 


### PR DESCRIPTION
If proc is mounted in rootfs (e.g., via chroot), rsync will try copying kcore
when permitted to cross file system boundaries.