### PR TITLE
adding dosfstools as a build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 #Dependencies
 
-`quilt kpartx realpath qemu-user-static debootstrap zerofree pxz zip`
+`quilt kpartx realpath qemu-user-static debootstrap zerofree pxz zip dosfstools`
 
 #Config
 

--- a/depends
+++ b/depends
@@ -3,3 +3,4 @@ qemu-arm-static:qemu-user-static
 debootstrap
 kpartx zerofree
 pxz zip
+dosfstools


### PR DESCRIPTION
`build.sh` complained about `mkdosfs` not being found. Installing `dosfstools` makes it go away.