### PR TITLE
adding mkdosfs to depends file

### DIFF
--- a/depends
+++ b/depends
@@ -3,4 +3,4 @@ qemu-arm-static:qemu-user-static
 debootstrap
 kpartx zerofree
 pxz zip
-dosfstools
+mkdosfs:dosfstools


### PR DESCRIPTION
Previously I added `dosfstools` to depends file, but forgot to put `mkdosfs` as the command to check.