### PR TITLE
Document warning for binfmt-support requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,12 @@ You can then remove the build container with `docker rm pigen_work`
 
 If something breaks along the line, you can edit the corresponding scripts, and
 continue:
+
 ```
 CONTINUE=1 ./build-docker.sh
 ```
+
+There is a possibility that even when running from a docker container, the installation of `qemu-user-static` will silently fail when building the image because `binfmt-support` _must be enabled on the underlying kernel_. An easy fix is to ensure `binfmt-support` is installed on the host machine before starting the `./build-docker.sh` script (or using your own docker build solution).
 
 ## Stage Anatomy
 
@@ -100,7 +103,7 @@ maintenance and allows for more easy customization.
    wolfram-engine, system documentation, office productivity, etc.  This is
    the stage that installs all of the things that make Raspbian friendly to
    new users.
-   
+
 ### Stage specification
 If you wish to build up to a specified stage (such as building up to stage 2 for a lite system), place an empty file named `SKIP` in each of the `./stage` directories you wish not to include.
 


### PR DESCRIPTION
Refs #45.

A bit of a weird one, as it'll only occur when attempting to build from `Docker`. As mentioned in the issue and the commit, if the underlying kernel doesn't have support for `binfmt` then the `qemu-user-static` installation will fail (pretty much) silently upon building the docker image.

The ensuing docker build process will then not be able to virtually chroot (and will also fail).

There is no easy fix for this as right now we need `qemu-user-static` for ARM emulation, so I've added a small bit of documentation in the README that'll hopefully save someone the hours of debugging I just went through!