### PR TITLE
Enable pi-gen build when "pi-gen/work" dir is a symlink

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -132,7 +132,7 @@ export IMG_DATE=${IMG_DATE:-"$(date -u +%Y-%m-%d)"}
 
 export BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export SCRIPT_DIR="${BASE_DIR}/scripts"
-export WORK_DIR="${BASE_DIR}/work/${IMG_DATE}-${IMG_NAME}"
+export WORK_DIR=`readlink -f "${BASE_DIR}/work/${IMG_DATE}-${IMG_NAME}"`
 export DEPLOY_DIR="${BASE_DIR}/deploy"
 export LOG_FILE="${WORK_DIR}/build.log"
 


### PR DESCRIPTION
* Occasionally, it is necessary to symbolically link the pi-gen/work
  directory to a different place on the filesystem.  This is true if
  the current partition is low on space, or when building within
  vagrant virtual machine shared mounts which do not support all
  regular fs operations.
* Without this change, the pi-gen build will fail to unmount because
  the OS 'mount' command returns canonical paths which fails to match
  the symbolically linked path to 'work' dir.