### PR TITLE
Tell docker to delete the volume as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ vi config         # Edit your config file. See above.
 ```
 
 If everything goes well, your finished image will be in the `deploy/` folder.
-You can then remove the build container with `docker rm pigen_work`
+You can then remove the build container with `docker rm -v pigen_work`
 
 If something breaks along the line, you can edit the corresponding scripts, and
 continue:

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -45,7 +45,7 @@ fi
 if [ "$CONTAINER_EXISTS" != "" ] && [ "$CONTINUE" != "1" ]; then
 	echo "Container $CONTAINER_NAME already exists and you did not specify CONTINUE=1. Aborting."
 	echo "You can delete the existing container like this:"
-	echo "  docker rm $CONTAINER_NAME"
+	echo "  docker rm -v $CONTAINER_NAME"
 	exit 1
 fi
 


### PR DESCRIPTION
Addresses #62

Because of the use of volumes the .img files (and everything else) will stay around on disk even when you do `docker rm pigen_work`. Passing `-v` deletes the volume as well and frees up disk space.