### PR TITLE
Image build date now honours timezone

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -128,7 +128,7 @@ if [ -z "${IMG_NAME}" ]; then
 	exit 1
 fi
 
-export IMG_DATE=${IMG_DATE:-"$(date -u +%Y-%m-%d)"}
+export IMG_DATE=${IMG_DATE:-"$(date +%Y-%m-%d)"}
 
 export BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export SCRIPT_DIR="${BASE_DIR}/scripts"


### PR DESCRIPTION
This is to address #72 by removing the UTC switch from the call to `date`. The docker build will still by default use UTC unless its timezone has been changed.

The variable `IMG_DATE` can be specified in the `config` file, to override this date too.