### PR TITLE
Export-image: Only disable metadata_csum feature if it's possibly ena…

### DIFF
--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -50,8 +50,12 @@ ROOT_DEV=$(losetup --show -f -o ${ROOT_OFFSET} --sizelimit ${ROOT_LENGTH} ${IMG_
 echo "/boot: offset $BOOT_OFFSET, length $BOOT_LENGTH"
 echo "/:     offset $ROOT_OFFSET, length $ROOT_LENGTH"
 
+ROOT_FEATURES="^huge_file"
+if grep -q "metadata_csum" /etc/mke2fs.conf; then
+    ROOT_FEATURES="^metadata_csum,$ROOT_FEATURES"
+fi
 mkdosfs -n boot -F 32 -v $BOOT_DEV > /dev/null
-mkfs.ext4 -O ^metadata_csum,^huge_file $ROOT_DEV > /dev/null
+mkfs.ext4 -O $ROOT_FEATURES $ROOT_DEV > /dev/null
 
 mount -v $ROOT_DEV ${ROOTFS_DIR} -t ext4
 mkdir -p ${ROOTFS_DIR}/boot


### PR DESCRIPTION
…bled.
This is to address #84 by checking the configuration file for mke2fs on the host system to search for "metadata_csum" before passing it as an option to mkfs.ext4.
The assumption is that if this text does not exist in the configuration file, then either the e2fsprogs is outdated and won't support it, or the feature is just not enabled on any of the configured defaults. Either way, the build script won't need to try to disable it when exporting the image.