### PR TITLE
Added docker-compose.yml for easy apt-cacher-ng startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ postrun.sh
 SKIP
 .pc
 *-pc
+apt-cacher-ng/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ The following environment variables are supported:
    will not be included in the image, making it safe to use an `apt-cacher` or
    similar package for development.
 
+   If you have Docker installed, you can set up a local apt caching proxy to
+   like speed up subsequent builds like this:
+
+       docker-compose up -d
+       echo 'APT_PROXY=http://172.17.0.1:3142' >> config
+
  * `BASE_DIR`  (Default: location of `build.sh`)
 
    **CAUTION**: Currently, changing this value will probably break build.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+  apt-cacher-ng:
+    restart: unless-stopped
+    image: sameersbn/apt-cacher-ng:latest
+    ports:
+    - "3142:3142"
+    volumes:
+    - ./apt-cacher-ng:/var/cache/apt-cacher-ng


### PR DESCRIPTION
Tested using docker-build.sh. Gives a huge speedup and makes it dead-simple to start a local APT proxy.