### PR TITLE
Docker build: move to debian stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:jessie
+FROM debian:stretch
 
 RUN apt-get -y update && \
     apt-get -y install \
         git vim parted \
         quilt realpath qemu-user-static debootstrap zerofree pxz zip dosfstools \
-        bsdtar libcap2-bin rsync grep \
+        bsdtar libcap2-bin rsync grep udev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /pi-gen/

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -12,9 +12,10 @@ if ! $DOCKER ps >/dev/null; then
 fi
 set -e
 
-config_mount="/dev/null:/dev/null"
+
+config_mount=()
 if [ -f config ]; then
-	config_mount="$(pwd)/config:/pi-gen/config:ro"
+	config_mount=("-v" "$(pwd)/config:/pi-gen/config:ro")
 	source config
 fi
 
@@ -65,7 +66,7 @@ else
 	$DOCKER run --name "${CONTAINER_NAME}" --privileged \
 		-e IMG_NAME=${IMG_NAME}\
 		-v "$(pwd)/deploy:/pi-gen/deploy" \
-		-v "${config_mount}" \
+		"${config_mount[@]}" \
 		pi-gen \
 		bash -e -o pipefail -c "dpkg-reconfigure qemu-user-static &&
 	cd /pi-gen; ./build.sh &&


### PR DESCRIPTION
Fixes #84.

Looks like the stretch docker image drops `udevadm` by default... need to pull that back in.