### PR TITLE
Check for curl as a dependency for export-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -y update && \
     apt-get -y install \
         git vim parted \
         quilt realpath qemu-user-static debootstrap zerofree pxz zip dosfstools \
-        bsdtar libcap2-bin rsync grep udev xz-utils \
+        bsdtar libcap2-bin rsync grep udev xz-utils curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /pi-gen/

--- a/depends
+++ b/depends
@@ -11,3 +11,4 @@ bsdtar
 grep
 rsync
 xz:xz-utils
+curl


### PR DESCRIPTION
This pull request is a result is to address a new dependency on "curl" that is currently unchecked.

Without this commit, the build process will get all the way to the export-image step, then fail if "curl" is not installed on the host system.

This dependency was added with:
7149e20f2d919efdafc325602c373aee35b27023 "export-image: generate .info file"
However, curl was not added to the depends file to ensure the dependency is satisfied.