### PR TITLE
export-image: when work in a non-English locale environment the PARTUUID will silently fail, resulting to an unbootable image file. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -y update && \
     apt-get -y install \
         git vim parted \
         quilt realpath qemu-user-static debootstrap zerofree pxz zip dosfstools \
-        bsdtar libcap2-bin rsync grep udev xz-utils curl \
+        bsdtar libcap2-bin rsync grep udev xz-utils curl xxd \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /pi-gen/

--- a/depends
+++ b/depends
@@ -12,3 +12,4 @@ grep
 rsync
 xz:xz-utils
 curl
+xxd

--- a/export-image/03-set-partuuid/00-run.sh
+++ b/export-image/03-set-partuuid/00-run.sh
@@ -2,7 +2,7 @@
 
 IMG_FILE="${STAGE_WORK_DIR}/${IMG_DATE}-${IMG_NAME}${IMG_SUFFIX}.img"
 
-IMGID="$(fdisk -l ${IMG_FILE} | sed -n 's/Disk identifier: 0x\([^ ]*\)/\1/p')"
+IMGID="$(dd if=${IMG_FILE} skip=440 bs=1 count=4 2>/dev/null | xxd -e | cut -f 2 -d' ')"
 
 BOOT_PARTUUID="${IMGID}-01"
 ROOT_PARTUUID="${IMGID}-02"


### PR DESCRIPTION
Because in locale like zh_CN.utf-8 the `Disk identifier` becomes `磁盘标识符`. Sed will silently fail.
so I use dd and xxd to directly read the disk identifier out.