### PR TITLE
Added .travis.yml to CI docker building of images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+
+language: generic
+
+services:
+- docker
+
+script:
+
+- echo 'IMG_NAME="Raspbian"' >> config
+
+# only build up to stage 2. We don't have enough space for NOOBS on travis.
+- touch stage{3,4,5}/SKIP
+- rm -f stage{3,4,5}/EXPORT_*
+
+- ./build-docker.sh
+- ls -lahR deploy
+- "[ -s deploy/*.zip ]"


### PR DESCRIPTION
This builds stage2 (a -lite) image on travis, to check whether added depencies break the build.

Example builds are on https://travis-ci.org/cfstras/pi-gen