### PR TITLE
Add a Qemu mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The following environment variables are supported:
 
    Output directory for target system images and NOOBS bundles.
 
+ * `USE_QEMU` (Default: `"0"`)
+
+   This enable the Qemu mode and set filesystem and image suffix if set to 1.
+
 
 A simple example for building Raspbian:
 

--- a/build.sh
+++ b/build.sh
@@ -119,6 +119,7 @@ if [ "$(id -u)" != "0" ]; then
 	exit 1
 fi
 
+
 if [ -f config ]; then
 	source config
 fi
@@ -128,6 +129,7 @@ if [ -z "${IMG_NAME}" ]; then
 	exit 1
 fi
 
+export USE_QEMU=${USE_QEMU:-0}
 export IMG_DATE=${IMG_DATE:-"$(date +%Y-%m-%d)"}
 
 export BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -177,10 +179,12 @@ for EXPORT_DIR in ${EXPORT_DIRS}; do
 	source "${EXPORT_DIR}/EXPORT_IMAGE"
 	EXPORT_ROOTFS_DIR=${WORK_DIR}/$(basename ${EXPORT_DIR})/rootfs
 	run_stage
-	if [ -e ${EXPORT_DIR}/EXPORT_NOOBS ]; then
-		source ${EXPORT_DIR}/EXPORT_NOOBS
-		STAGE_DIR=${BASE_DIR}/export-noobs
-		run_stage
+	if [ "${USE_QEMU}" != "1" ]; then
+		if [ -e ${EXPORT_DIR}/EXPORT_NOOBS ]; then
+			source ${EXPORT_DIR}/EXPORT_NOOBS
+			STAGE_DIR=${BASE_DIR}/export-noobs
+			run_stage
+		fi
 	fi
 done
 

--- a/export-image/04-finalise/01-run.sh
+++ b/export-image/04-finalise/01-run.sh
@@ -15,8 +15,10 @@ fi
 rm -f ${ROOTFS_DIR}/etc/apt/apt.conf.d/51cache
 rm -f ${ROOTFS_DIR}/usr/sbin/policy-rc.d
 rm -f ${ROOTFS_DIR}/usr/bin/qemu-arm-static
-if [ -e ${ROOTFS_DIR}/etc/ld.so.preload.disabled ]; then
-        mv ${ROOTFS_DIR}/etc/ld.so.preload.disabled ${ROOTFS_DIR}/etc/ld.so.preload
+if [ "${USE_QEMU}" != "1" ]; then
+	if [ -e ${ROOTFS_DIR}/etc/ld.so.preload.disabled ]; then
+		mv ${ROOTFS_DIR}/etc/ld.so.preload.disabled ${ROOTFS_DIR}/etc/ld.so.preload
+	fi
 fi
 
 rm -f ${ROOTFS_DIR}/etc/apt/sources.list~

--- a/stage2/01-sys-tweaks/01-run.sh
+++ b/stage2/01-sys-tweaks/01-run.sh
@@ -17,8 +17,28 @@ systemctl disable nfs-common
 systemctl disable rpcbind
 systemctl disable ssh
 systemctl enable regenerate_ssh_host_keys
+EOF
+
+if [ "${USE_QEMU}" = "1" ]; then
+	echo "enter QEMU mode"
+	install -m 644 files/90-qemu.rules		${ROOTFS_DIR}/etc/udev/rules.d/
+	if [ -e ${ROOTFS_DIR}/etc/ld.so.preload.disabled ]; then
+		rm ${ROOTFS_DIR}/etc/ld.so.preload.disabled
+		touch ${ROOTFS_DIR}/etc/ld.so.preload.disabled
+	fi
+	if [ -e ${ROOTFS_DIR}/etc/ld.so.preload ]; then
+		rm ${ROOTFS_DIR}/etc/ld.so.preload
+		touch ${ROOTFS_DIR}/etc/ld.so.preload
+	fi
+	on_chroot << EOF
+systemctl disable resize2fs_once
+EOF
+	echo "leaving QEMU mode"
+else
+	on_chroot << EOF
 systemctl enable resize2fs_once
 EOF
+fi
 
 on_chroot << \EOF
 for GRP in input spi i2c gpio; do

--- a/stage2/01-sys-tweaks/files/90-qemu.rules
+++ b/stage2/01-sys-tweaks/files/90-qemu.rules
@@ -1,0 +1,3 @@
+KERNEL=="sda", SYMLINK+="mmcblk0"
+KERNEL=="sda?", SYMLINK+="mmcblk0p%n"
+KERNEL=="sda2", SYMLINK+="root"

--- a/stage2/EXPORT_IMAGE
+++ b/stage2/EXPORT_IMAGE
@@ -1,1 +1,4 @@
 IMG_SUFFIX="-lite"
+if [ "${USE_QEMU}" = "1" ]; then
+	export IMG_SUFFIX="${IMG_SUFFIX}-qemu"
+fi

--- a/stage4/EXPORT_IMAGE
+++ b/stage4/EXPORT_IMAGE
@@ -1,1 +1,4 @@
 IMG_SUFFIX="-4GB"
+if [ "${USE_QEMU}" = "1" ]; then
+	export IMG_SUFFIX="${IMG_SUFFIX}-qemu"
+fi

--- a/stage5/EXPORT_IMAGE
+++ b/stage5/EXPORT_IMAGE
@@ -1,1 +1,4 @@
 IMG_SUFFIX=""
+if [ "${USE_QEMU}" = "1" ]; then
+	export IMG_SUFFIX="${IMG_SUFFIX}-qemu"
+fi


### PR DESCRIPTION
This branch contains some minor fixes and a new feature.

It will be possible to create Qemu compatible image (usefull to test fixes or changes in Qemu without having to setup a new real rpi).

This is possible with a parameter QEMU_MODE="true"|"false".
If QEMU_MODE == "true" the images are configured to boot on Qemu but not on a real RPI, -qemu is append at the end of the image file to avoid mistakes.