### PR TITLE
fix docker-in-docker copying when not doing CONTINUE=1

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -71,10 +71,10 @@ else
 	cd /pi-gen; ./build.sh &&
 	rsync -av work/*/build.log deploy/" &
 	wait "$!"
-	$DOCKER rm -v $CONTAINER_NAME
 fi
 echo "copying results from deploy/"
 $DOCKER cp "${CONTAINER_NAME}":/pi-gen/deploy .
 ls -lah deploy
+$DOCKER rm -v $CONTAINER_NAME
 
 echo "Done! Your image(s) should be in deploy/"


### PR DESCRIPTION
Sorry for the second pull request -- when running this again I noticed it was deleting the container too early.

This fixes that and also deletes the container always -- only if the build was successful.