### PR TITLE
Avoid rsync options -o & -g on vfat

### DIFF
--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -64,4 +64,5 @@ mount -v $ROOT_DEV ${ROOTFS_DIR} -t ext4
 mkdir -p ${ROOTFS_DIR}/boot
 mount -v $BOOT_DEV ${ROOTFS_DIR}/boot -t vfat
 
-rsync -aHAXx --exclude var/cache/apt/archives ${EXPORT_ROOTFS_DIR}/ ${ROOTFS_DIR}/
+rsync -aHAXx --exclude boot --exclude var/cache/apt/archives ${EXPORT_ROOTFS_DIR}/      ${ROOTFS_DIR}/
+rsync -aHAXx --no-o --no-g  --exclude var/cache/apt/archives ${EXPORT_ROOTFS_DIR}/boot/ ${ROOTFS_DIR}/boot/


### PR DESCRIPTION
Fixes https://github.com/RPi-Distro/pi-gen/issues/119

My custom build stage was dropping a 2 text files on /boot and that
was causing rsync to fail on my stage when it didn't fail on stage2.

Before making this change I was getting this error:

    + mkdosfs -n boot -F 32 -v /dev/loop0
    mkfs.fat: warning - lowercase labels might not work properly with DOS or Windows
    + mkfs.ext4 -O '^huge_file' /dev/loop1
    mke2fs 1.42.13 (17-May-2015)
    + mount -v /dev/loop1 /home/ubuntu/ies_rpi/pi-gen/work/2017-10-04-Raspbian/export-image/rootfs -t ext4
    mount: /dev/loop1 mounted on /home/ubuntu/ies_rpi/pi-gen/work/2017-10-04-Raspbian/export-image/rootfs.
    + mkdir -p /home/ubuntu/ies_rpi/pi-gen/work/2017-10-04-Raspbian/export-image/rootfs/boot
    + mount -v /dev/loop0 /home/ubuntu/ies_rpi/pi-gen/work/2017-10-04-Raspbian/export-image/rootfs/boot -t vfat
    mount: /dev/loop0 mounted on /home/ubuntu/ies_rpi/pi-gen/work/2017-10-04-Raspbian/export-image/rootfs/boot.
    + rsync -aHAXx --exclude var/cache/apt/archives /home/ubuntu/ies_rpi/pi-gen/work/2017-10-04-Raspbian/stage4/rootfs/ /home/ubuntu/ies_rpi/pi-gen/work/201
    7-10-04-Raspbian/export-image/rootfs/
    rsync: chown "/home/ubuntu/ies_rpi/pi-gen/work/2017-10-04-Raspbian/export-image/rootfs/boot/.meta-data.57XaxF" failed: Operation not permitted (1)
    rsync: chown "/home/ubuntu/ies_rpi/pi-gen/work/2017-10-04-Raspbian/export-image/rootfs/boot/.user-data.9Icrdz" failed: Operation not permitted (1)
    rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1183) [sender=3.1.1]