### PR TITLE
Remove /etc/vnc/updateid when finalising

### DIFF
--- a/export-image/04-finalise/01-run.sh
+++ b/export-image/04-finalise/01-run.sh
@@ -45,6 +45,7 @@ for _FILE in $(find ${ROOTFS_DIR}/var/log/ -type f); do
 done
 
 rm -f "${ROOTFS_DIR}/root/.vnc/private.key"
+rm -f "${ROOTFS_DIR}/etc/vnc/updateid"
 
 update_issue $(basename ${EXPORT_DIR})
 install -m 644 ${ROOTFS_DIR}/etc/rpi-issue ${ROOTFS_DIR}/boot/issue.txt


### PR DESCRIPTION
The file /etc/vnc/updateid contains an ID generated upon installation, which is supposed to be a unique ID used by the vnc update notification service. However, since this file is present on the disk image, it is the same for all installations.

This change removes this file when finalising the disk image, so it will get regenerated properly if/when the server is first run.
