### PR TITLE
Allow image building to be skipped for stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ work/*
 config
 postrun.sh
 SKIP
+SKIP_IMAGES
 .pc
 *-pc
 apt-cacher-ng/

--- a/README.md
+++ b/README.md
@@ -228,14 +228,14 @@ replace with your own contents in the same format.
 If you're working on a specific stage the recommended development process is as
 follows:
 
- * Remove the EXPORT_IMAGE and EXPORT_NOOBS files until you're ready to actually
-   generate an image
+ * Add a file called SKIP_IMAGES into the directories containing EXPORT_* files
+   (currently stage2, stage4 and stage5)
  * Add SKIP files to the stages you don't want to build. For example, if you're
    basing your image on the lite image you would add these to stages 3, 4 and 5.
  * Run build.sh to build all stages
  * Add SKIP files to the earlier successfully built stages
  * Modify the last stage
  * Rebuild just the last stage using ```sudo CLEAN=1 ./build.sh```
- * Once you're happy with the image you can add the EXPORT files back in and
+ * Once you're happy with the image you can remove the SKIP_IMAGES files and
    export your image to test
 

--- a/build.sh
+++ b/build.sh
@@ -85,8 +85,10 @@ run_stage(){
 	unmount ${WORK_DIR}/${STAGE}
 	STAGE_WORK_DIR=${WORK_DIR}/${STAGE}
 	ROOTFS_DIR=${STAGE_WORK_DIR}/rootfs
-	if [ -f ${STAGE_DIR}/EXPORT_IMAGE ]; then
-		EXPORT_DIRS="${EXPORT_DIRS} ${STAGE_DIR}"
+	if [ ! -f SKIP_IMAGES ]; then
+		if [ -f ${STAGE_DIR}/EXPORT_IMAGE ]; then
+			EXPORT_DIRS="${EXPORT_DIRS} ${STAGE_DIR}"
+		fi
 	fi
 	if [ ! -f SKIP ]; then
 		if [ "${CLEAN}" = "1" ]; then


### PR DESCRIPTION
Whilst working on a fork of this repo to build my own images I added this modification which allows you to skip exporting images for stages (in the same way you can just skip a stage with SKIP files). There are two main reasons for wanting to do this;
 - it means you can make fewer changes to a fork of the repo and keep it in sync more easily and don't accidentally commit the removal of the export file
 - the EXPORT_* files aren't just empty but contain configuration so this makes it easier to just turn on and off image building during development

It's a pretty straightforward change to the build script.