### PR TITLE
Added Button SHIM, Unicorn HAT HD and Pan Tilt HAT

### DIFF
--- a/stage4/00-install-packages/01-packages
+++ b/stage4/00-install-packages/01-packages
@@ -17,3 +17,6 @@ python-scrollphathd python3-scrollphathd
 python-sn3218 python3-sn3218
 python-skywriter python3-skywriter
 python-touchphat python3-touchphat
+python-buttonshim python3-buttonshim
+python-unicornhathd  python3-unicornhathd
+python-pantilthat python3-pantilthat


### PR DESCRIPTION
I humbly request the inclusion of Python 2.x and 3.x libraries for Button SHIM, Unicorn HAT HD and Pan Tilt HAT to join the others we've deployed so far.

Cumulative size: 347KB.

* python-buttonshim - Installed Size: 58KB
* python3-buttonshim - Installed Size: 58KB
* python-unincornhathd - Installed Size: 50KB
* python3-unicornhathd - Installed Size: 51KB
* python-pantilthat - Installed Size: 65KB
* python3-pantilthat - Installed Size: 65KB

Note: The 0.0.2 release of Button SHIM has *just* been submitted to staging. All of these libraries have been updated to remove the import-time side-effects which were raised here: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502