### PR TITLE
Remove quotes in globbed patch CLEANup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ EOF
 			pushd "${STAGE_WORK_DIR}" > /dev/null
 			if [ "${CLEAN}" = "1" ]; then
 				rm -rf .pc
-				rm -rf "./*-pc"
+				rm -rf ./*-pc
 			fi
 			QUILT_PATCHES="${SUB_STAGE_DIR}/${i}-patches"
 			SUB_STAGE_QUILT_PATCH_DIR="$(basename "$SUB_STAGE_DIR")-pc"


### PR DESCRIPTION
Globbing does not work within single or double quotes.

Because of this, at least some patches were not being applied on rebuilds, regardless of the CLEAN setting.

Note that the shellcheck commit that introduced the quotes (ff2d5ed) also quoted [three globs](https://github.com/davesteele/pi-gen/blob/comitup/export-image/04-finalise/01-run.sh#L26) in export.