### PR TITLE
Default CLEAN to '1'

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ follows:
  * Run build.sh to build all stages
  * Add SKIP files to the earlier successfully built stages
  * Modify the last stage
- * Rebuild just the last stage using ```sudo CLEAN=1 ./build.sh```
+ * Rebuild just the last stage using ```sudo ./build.sh```
  * Once you're happy with the image you can remove the SKIP_IMAGES files and
    export your image to test
 

--- a/build.sh
+++ b/build.sh
@@ -143,7 +143,7 @@ export LOG_FILE="${WORK_DIR}/build.log"
 
 export BASE_DIR
 
-export CLEAN
+export CLEAN=${CLEAN:-"1"}
 export IMG_NAME
 export APT_PROXY
 


### PR DESCRIPTION
The CLEAN processes really need to run anytime 'prerun.sh' is run,
and that script is run every time. e.g. If CLEAN != 1, the quilt
.pc dirs are not cleared, causing any patches to not be applied.

As an alternative, ensure that the .pc directories are always cleared, regardless of CLEAN, and review/revise the rsync call in copy_previous (in particular, --delete*)