### PR TITLE
Fix some quoted globs in export-image cleanup

### DIFF
--- a/export-image/04-finalise/01-run.sh
+++ b/export-image/04-finalise/01-run.sh
@@ -23,10 +23,10 @@ rm -f "${ROOTFS_DIR}/etc/group-"
 rm -f "${ROOTFS_DIR}/etc/shadow-"
 rm -f "${ROOTFS_DIR}/etc/gshadow-"
 
-rm -f "${ROOTFS_DIR}/var/cache/debconf/*-old"
-rm -f "${ROOTFS_DIR}/var/lib/dpkg/*-old"
+rm -f "${ROOTFS_DIR}"/var/cache/debconf/*-old
+rm -f "${ROOTFS_DIR}"/var/lib/dpkg/*-old
 
-rm -f "${ROOTFS_DIR}/usr/share/icons/*/icon-theme.cache"
+rm -f "${ROOTFS_DIR}"/usr/share/icons/*/icon-theme.cache
 
 rm -f "${ROOTFS_DIR}/var/lib/dbus/machine-id"
 


### PR DESCRIPTION
A few more bash globs were being disabled by quotes.