### PR TITLE
stage1: add missing netbase package to the net-tweaks sub stage

### DIFF
--- a/stage1/02-net-tweaks/00-packages
+++ b/stage1/02-net-tweaks/00-packages
@@ -1,0 +1,1 @@
+netbase


### PR DESCRIPTION
Hello, this PR adds the missing package `netbase` to stage 1 -> net tweaks.
I'm building an "ultra lite" Raspbian image using the `minbase` variant in debootstrap and in this mode, the `netbase` package is not installed by default and hence the patching of the `/etc/hosts` from it fails.

I believe that this package (`netbase`) should be ensured to be installed in stage 1 because of this stage trying to patch a file from it (`/etc/hosts`), regardless of how debootstrap generated the initial distribution in stage 0.

This PR is harmless for current pi-gen but beneficial for advanced users that wishes to customise the image without hassle.
