### PR TITLE
stage0: add missing raspberrypi-kernel package to the firmware sub stage

### DIFF
--- a/stage0/02-firmware/01-packages
+++ b/stage0/02-firmware/01-packages
@@ -1,1 +1,2 @@
 raspberrypi-bootloader
+raspberrypi-kernel


### PR DESCRIPTION
Hello again, similar to PR #184 , this PR adds the package `raspberrypi-kernel` to stage 0 -> firmware to be guaranteed to be installed.
When building an "ultra lite" Raspbian image using the minbase variant in debootstrap, the `raspberrypi-kernel` package is not installed by default and hence the system is left without a kernel.
With this PR, the `raspberrypi-kernel` package is ensured to be installed in stage 0 alongside `raspberrypi-bootloader`, regardless of how debootstrap generated the initial distribution in stage 0.

This PR is harmless for current pi-gen but beneficial for advanced users that wishes to customise the image without hassle.