### PR TITLE
export-image: clean additional backup files

### DIFF
--- a/export-image/04-finalise/01-run.sh
+++ b/export-image/04-finalise/01-run.sh
@@ -22,6 +22,8 @@ rm -f "${ROOTFS_DIR}/etc/passwd-"
 rm -f "${ROOTFS_DIR}/etc/group-"
 rm -f "${ROOTFS_DIR}/etc/shadow-"
 rm -f "${ROOTFS_DIR}/etc/gshadow-"
+rm -f "${ROOTFS_DIR}/etc/subuid-"
+rm -f "${ROOTFS_DIR}/etc/subgid-"
 
 rm -f "${ROOTFS_DIR}"/var/cache/debconf/*-old
 rm -f "${ROOTFS_DIR}"/var/lib/dpkg/*-old


### PR DESCRIPTION
Hi again, here is another small improvement.
I noticed that in recent builds there are two backup files (`/etc/sub{u,g}id-`) that aren't cleaned in the export-image -> finalize substage.
This PR fixes adds those files to the cleaning phase.