### PR TITLE
add support for /boot/rc.local.txt if exists

### DIFF
--- a/stage2/01-sys-tweaks/files/rc.local
+++ b/stage2/01-sys-tweaks/files/rc.local
@@ -18,7 +18,7 @@ if [ "$_IP" ]; then
 fi
 
 # run an rc.local.txt from the boot partition, if one exists.
-if [[ -e /boot/rc.local.txt ]]; then
+if [ -e /boot/rc.local.txt ]; then
   source /boot/rc.local.txt
 fi
 

--- a/stage2/01-sys-tweaks/files/rc.local
+++ b/stage2/01-sys-tweaks/files/rc.local
@@ -17,4 +17,9 @@ if [ "$_IP" ]; then
   printf "My IP address is %s\n" "$_IP"
 fi
 
+# run an rc.local.txt from the boot partition, if one exists.
+if [[ -e /boot/rc.local.txt ]]; then
+  source /boot/rc.local.txt
+fi
+
 exit 0

--- a/stage2/01-sys-tweaks/files/rc.local
+++ b/stage2/01-sys-tweaks/files/rc.local
@@ -19,7 +19,7 @@ fi
 
 # run an rc.local.txt from the boot partition, if one exists.
 if [ -e /boot/rc.local.txt ]; then
-  source /boot/rc.local.txt
+  . /boot/rc.local.txt
 fi
 
 exit 0


### PR DESCRIPTION
This adds a stanza to the raspbian rc.local that will source the contents of a /boot/rc.local.txt if one exists.

This allows for a Windows or macOS user to image with a stock raspbian image, then mount the boot partition which is vfat (supported well under Windows and macOS) and drop an `rc.local.txt` on it with their own local configuration, then install it into a pi and boot it.  This allows for e.g. configuration of wifi or provisioning of SSH keys easily without requiring a keyboard/monitor.  Otherwise, the user would have to grok the pi-gen repo and build their own custom image with their local configuration, or connect video/keyboard.  Both are suboptimal.

If the user declines to drop an `rc.local.txt` file in the vfat boot partition, there is no change from default behavior.