### PR TITLE
Only track non-skipped stages in `PREV_` variables

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -108,11 +108,11 @@ run_stage(){
 				run_sub_stage
 			fi
 		done
+		PREV_ROOTFS_DIR="${ROOTFS_DIR}"
+		PREV_STAGE="${STAGE}"
+		PREV_STAGE_DIR="${STAGE_DIR}"
 	fi
 	unmount "${WORK_DIR}/${STAGE}"
-	PREV_STAGE="${STAGE}"
-	PREV_STAGE_DIR="${STAGE_DIR}"
-	PREV_ROOTFS_DIR="${ROOTFS_DIR}"
 	popd > /dev/null
 	log "End ${STAGE_DIR}"
 }


### PR DESCRIPTION
Only set `PREV_STAGE`, `PREV_STAGE_DIR` and `PREV_ROOTFS_DIR` when the
stage is actually built.

When building a custom image, I wanted to make the least modifications
to this repo, so I've added `SKIP` files to `stage3` and `stage4`, and
created my own `stage5`, but this confused `copy_previous`, which was
trying to copy the rootfs from a un-built stage. This fixes this issue.