### PR TITLE
Add username validation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -189,6 +189,11 @@ source "${SCRIPT_DIR}/common"
 # shellcheck source=scripts/dependencies_check
 source "${SCRIPT_DIR}/dependencies_check"
 
+#check username is valid
+if [[ ! "$FIRST_USER_NAME" =~ ^[a-z][-a-z0-9_]*$ ]]; then
+	echo "Invalid FIRST_USER_NAME: $FIRST_USER_NAME"
+	exit 1
+fi
 
 dependencies_check "${BASE_DIR}/depends"
 

--- a/stage2/02-net-tweaks/01-run.sh
+++ b/stage2/02-net-tweaks/01-run.sh
@@ -14,6 +14,6 @@ fi
 if [ -v WPA_ESSID -a -v WPA_PASSWORD ]
 then
 on_chroot <<EOF
-wpa_passphrase ${WPA_ESSID} ${WPA_PASSWORD} >> "/etc/wpa_supplicant/wpa_supplicant.conf"
+wpa_passphrase "${WPA_ESSID}" "${WPA_PASSWORD}" >> "/etc/wpa_supplicant/wpa_supplicant.conf"
 EOF
 fi


### PR DESCRIPTION
Check that the username is valid before doing any work. Use the default regex from debian's adduser.conf. Will also avoid risk of special characters causing issues.