### PR TITLE
Fixed a hard reference to the 'pi' user name

### DIFF
--- a/export-image/04-finalise/01-run.sh
+++ b/export-image/04-finalise/01-run.sh
@@ -8,8 +8,8 @@ on_chroot << EOF
 hardlink -t /usr/share/doc
 EOF
 
-if [ -d "${ROOTFS_DIR}/home/pi/.config" ]; then
-	chmod 700 "${ROOTFS_DIR}/home/pi/.config"
+if [ -d "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.config" ]; then
+	chmod 700 "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.config"
 fi
 
 rm -f "${ROOTFS_DIR}/etc/apt/apt.conf.d/51cache"


### PR DESCRIPTION
There was a recent commit to add the "FIRST_USER_NAME" option to config. In the export-image scripts, there was a section that still had a hard reference to the "pi" user name and did not respect the new "FIRST_USER_NAME" variable.

This pull request addresses that issue.