### PR TITLE
Fixed realpath dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ earlier releases of these systems.
 To install the required dependencies for pi-gen you should run:
 
 ```bash
-apt-get install quilt parted realpath qemu-user-static debootstrap zerofree pxz zip \
+apt-get install coreutils quilt parted qemu-user-static debootstrap zerofree pxz zip \
 dosfstools bsdtar libcap2-bin grep rsync xz-utils file git curl
 ```
 

--- a/depends
+++ b/depends
@@ -1,6 +1,6 @@
 quilt
 parted
-realpath
+realpath:coreutils
 qemu-arm-static:qemu-user-static
 debootstrap
 zerofree


### PR DESCRIPTION
On Debian 9, the package realpath is listed as *transitional package* ([see here](https://packages.debian.org/stretch/realpath)), and coreutils is the correct package to install it. Also on Ubuntu 18.04, realpath is not a standalone package in the repo, and is part of coreutils.

I've just updated the `README` and the `depends` file accordingly. The `dependancies_check()` will report the correct package to be installed (coreutils).