### PR TITLE
debootstrap: Directory not empty

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -20,7 +20,7 @@ bootstrap(){
 		--keyring "${STAGE_DIR}/files/raspberrypi.gpg" \
 		"$1" "$2" "$3" || true
 	if [ -d "$2/debootstrap" ]; then
-		rmdir "$2/debootstrap"
+		rm -rf "$2/debootstrap"
 	fi
 }
 export -f bootstrap


### PR DESCRIPTION
If the directory still contains files or subdirectories, the rmdir command does not remove the directory.