### PR TITLE
Add a DEPLOY_ZIP setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ The following environment variables are supported:
 
    Output directory for target system images and NOOBS bundles.
 
+ * `DEPLOY_ZIP` (Default: `1`)
+
+   Setting to `0` will deploy the actual image (`.img`) instead of a zipped image (`.zip`).
+
  * `USE_QEMU` (Default: `"0"`)
 
    Setting to '1' enables the QEMU mode - creating an image that can be mounted via QEMU for an emulated

--- a/build.sh
+++ b/build.sh
@@ -151,6 +151,7 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export SCRIPT_DIR="${BASE_DIR}/scripts"
 export WORK_DIR="${WORK_DIR:-"${BASE_DIR}/work/${IMG_DATE}-${IMG_NAME}"}"
 export DEPLOY_DIR=${DEPLOY_DIR:-"${BASE_DIR}/deploy"}
+export DEPLOY_ZIP="${DEPLOY_ZIP:-1}"
 export LOG_FILE="${WORK_DIR}/build.log"
 
 export FIRST_USER_NAME=${FIRST_USER_NAME:-pi}

--- a/export-image/04-finalise/01-run.sh
+++ b/export-image/04-finalise/01-run.sh
@@ -75,10 +75,15 @@ unmount_image "${IMG_FILE}"
 mkdir -p "${DEPLOY_DIR}"
 
 rm -f "${DEPLOY_DIR}/${ZIP_FILENAME}${IMG_SUFFIX}.zip"
+rm -f "${DEPLOY_DIR}/${IMG_FILENAME}${IMG_SUFFIX}.img"
 
-pushd "${STAGE_WORK_DIR}" > /dev/null
-zip "${DEPLOY_DIR}/${ZIP_FILENAME}${IMG_SUFFIX}.zip" \
-	"$(basename "${IMG_FILE}")"
-popd > /dev/null
+if [ "${DEPLOY_ZIP}" == "1" ]; then
+	pushd "${STAGE_WORK_DIR}" > /dev/null
+	zip "${DEPLOY_DIR}/${ZIP_FILENAME}${IMG_SUFFIX}.zip" \
+		"$(basename "${IMG_FILE}")"
+	popd > /dev/null
+else
+	cp "$IMG_FILE" "$DEPLOY_DIR"
+fi
 
 cp "$INFO_FILE" "$DEPLOY_DIR"


### PR DESCRIPTION
Currently, the produced `.img` file is zipped and copied to the deploy directory.

Of course this saves a lot of space when transferring the image, so I understand that it is an useful feature. However:
* When I'm building images locally I don't need the zipped image and the zipping/unzipping consumes a lot of time.
* Automatically building images using (GitLab) CI already compresses the artifacts, resulting in nested `.zip` files.

This PR adds an option to disable zipping the final image.