### PR TITLE
Document IMG_DATE & fix an hard-coded hyphen 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following environment variables are supported:
    be built and cached.  Note, `WORK_DIR` stores a complete copy of the target
    system for each build stage, amounting to tens of gigabytes in the case of
    Raspbian.
-   
+
    **CAUTION**: If your working directory is on an NTFS partition you probably won't be able to build. Make sure this is a proper Linux filesystem.
 
  * `DEPLOY_DIR`  (Default: `"$BASE_DIR/deploy"`)
@@ -72,6 +72,10 @@ The following environment variables are supported:
 
    Setting to '1' enables the QEMU mode - creating an image that can be mounted via QEMU for an emulated
    environment. These images include "-qemu" in the image file name.
+
+ * `IMG_DATE` (Default:`"$(date +%Y-%m-%d)-"`)
+    Define a string that will be prepend on directory name and images names.  
+    Setting it to `""` or any static string. Will prevent to have to rebuild from stage0 every morning.
 
 
 A simple example for building Raspbian:
@@ -248,4 +252,3 @@ follows:
  * Rebuild just the last stage using ```sudo CLEAN=1 ./build.sh```
  * Once you're happy with the image you can remove the SKIP_IMAGES files and
    export your image to test
-

--- a/build.sh
+++ b/build.sh
@@ -133,11 +133,11 @@ if [ -z "${IMG_NAME}" ]; then
 fi
 
 export USE_QEMU="${USE_QEMU:-0}"
-export IMG_DATE="${IMG_DATE:-"$(date +%Y-%m-%d)"}"
+export IMG_DATE="${IMG_DATE:-"$(date +%Y-%m-%d)-"}"
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export SCRIPT_DIR="${BASE_DIR}/scripts"
-export WORK_DIR="${WORK_DIR:-"${BASE_DIR}/work/${IMG_DATE}-${IMG_NAME}"}"
+export WORK_DIR="${WORK_DIR:-"${BASE_DIR}/work/${IMG_DATE}${IMG_NAME}"}"
 export DEPLOY_DIR=${DEPLOY_DIR:-"${BASE_DIR}/deploy"}
 export LOG_FILE="${WORK_DIR}/build.log"
 


### PR DESCRIPTION
Add a description of the environment variable IMG_DATE in the README file. 

Move an hardcoded hyphen between IMG_DATE and IMG_NAME into the IMG_DATE variable to prevent the case where IMG_DATE="" so the image name looks like `-raspbian-lite.iso`  