### PR TITLE
Silence shellcheck warnings and other minor improvements

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# shellcheck disable=SC2119,SC1091
+# shellcheck disable=SC2119
 run_sub_stage()
 {
 	log "Begin ${SUB_STAGE_DIR}"
@@ -102,7 +102,7 @@ run_stage(){
 			./prerun.sh
 			log "End ${STAGE_DIR}/prerun.sh"
 		fi
-		for SUB_STAGE_DIR in ${STAGE_DIR}/*; do
+		for SUB_STAGE_DIR in "${STAGE_DIR}"/*; do
 			if [ -d "${SUB_STAGE_DIR}" ] &&
 			   [ ! -f "${SUB_STAGE_DIR}/SKIP" ]; then
 				run_sub_stage
@@ -124,6 +124,7 @@ fi
 
 
 if [ -f config ]; then
+	# shellcheck disable=SC1091
 	source config
 fi
 
@@ -132,7 +133,10 @@ do
 	case "$flag" in
 		c)
 			EXTRA_CONFIG="$OPTARG"
+			# shellcheck disable=SC1090
 			source "$EXTRA_CONFIG"
+			;;
+		*)
 			;;
 	esac
 done
@@ -206,8 +210,8 @@ log "Begin ${BASE_DIR}"
 
 STAGE_LIST=${STAGE_LIST:-${BASE_DIR}/stage*}
 
-for STAGE_DIR_ in $STAGE_LIST; do
-	STAGE_DIR=`realpath "${STAGE_DIR_}"`
+for STAGE_DIR in $STAGE_LIST; do
+	STAGE_DIR=$(realpath "${STAGE_DIR}")
 	run_stage
 done
 

--- a/export-noobs/00-release/files/partition_setup.sh
+++ b/export-noobs/00-release/files/partition_setup.sh
@@ -3,6 +3,7 @@
 
 set -ex
 
+# shellcheck disable=SC2154
 if [ -z "$part1" ] || [ -z "$part2" ]; then
   printf "Error: missing environment variable part1 or part2\n" 1>&2
   exit 1
@@ -17,7 +18,8 @@ sed /tmp/1/cmdline.txt -i -e "s|root=[^ ]*|root=${part2}|"
 sed /tmp/2/etc/fstab -i -e "s|^[^#].* / |${part2}  / |"
 sed /tmp/2/etc/fstab -i -e "s|^[^#].* /boot |${part1}  /boot |"
 
-if [ -z $restore ]; then
+# shellcheck disable=SC2154
+if [ -z "$restore" ]; then
   if [ -f /mnt/ssh ]; then
     cp /mnt/ssh /tmp/1/
   fi

--- a/stage2/02-net-tweaks/01-run.sh
+++ b/stage2/02-net-tweaks/01-run.sh
@@ -6,13 +6,11 @@ install -v -m 644 files/wait.conf		"${ROOTFS_DIR}/etc/systemd/system/dhcpcd.serv
 install -v -d					"${ROOTFS_DIR}/etc/wpa_supplicant"
 install -v -m 600 files/wpa_supplicant.conf	"${ROOTFS_DIR}/etc/wpa_supplicant/"
 
-if [ -v WPA_COUNTRY ]
-then
+if [ -v WPA_COUNTRY ]; then
 	echo "country=${WPA_COUNTRY}" >> "${ROOTFS_DIR}/etc/wpa_supplicant/wpa_supplicant.conf"
 fi
 
-if [ -v WPA_ESSID -a -v WPA_PASSWORD ]
-then
+if [ -v WPA_ESSID ] && [ -v WPA_PASSWORD ]; then
 on_chroot <<EOF
 wpa_passphrase "${WPA_ESSID}" "${WPA_PASSWORD}" >> "/etc/wpa_supplicant/wpa_supplicant.conf"
 EOF


### PR DESCRIPTION
* Made more specific shellcheck disables
* Fixed variable quoting (SC2086,SC2064)
* Use `$*` expansion instead of `$@` when not using arrays (SC2124)
* Use cleaner `$()` syntax instead of back quotes (SC2006)
* Improved comparator (SC2166)
* Minor improvements in coding style

Tested clean output using: `find -name "*.sh" | xargs -n1 shellcheck -x`.

Tested a complete dist build too:
```
copying results from deploy/
total 3.2G
drwxr-xr-x  5 pi pi 4.0K Feb 14 17:49 .
drwxr-xr-x 13 pi pi 4.0K Feb 14 17:49 ..
drwxr-xr-x  2 pi pi 4.0K Feb 14 17:24 2019-02-14-raspbian-stretch
drwxr-xr-x  2 pi pi 4.0K Feb 14 17:49 2019-02-14-raspbian-stretch-full
-rw-r--r--  1 pi pi 200K Feb 14 17:35 2019-02-14-raspbian-stretch-full.info
-rw-r--r--  1 pi pi 160K Feb 14 17:18 2019-02-14-raspbian-stretch.info
drwxr-xr-x  2 pi pi 4.0K Feb 14 17:12 2019-02-14-raspbian-stretch-lite
-rw-r--r--  1 pi pi  54K Feb 14 17:09 2019-02-14-raspbian-stretch-lite.info
-rw-r--r--  1 pi pi  13K Feb 14 17:49 build.log
-rw-r--r--  1 pi pi 1.9G Feb 14 17:35 image_2019-02-14-raspbian-stretch-full.zip
-rw-r--r--  1 pi pi 352M Feb 14 17:09 image_2019-02-14-raspbian-stretch-lite.zip
-rw-r--r--  1 pi pi 1.1G Feb 14 17:18 image_2019-02-14-raspbian-stretch.zip
pigen_work
Done! Your image(s) should be in deploy/
```