### PR TITLE
Improve flexibility of two script common functions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -137,6 +137,9 @@ do
 	esac
 done
 
+export PI_GEN=${PI_GEN:-pi-gen}
+export PI_GEN_REPO=${PI_GEN_REPO:-https://github.com/RPi-Distro/pi-gen}
+
 if [ -z "${IMG_NAME}" ]; then
 	echo "IMG_NAME not set" 1>&2
 	exit 1

--- a/scripts/common
+++ b/scripts/common
@@ -96,7 +96,7 @@ export -f on_chroot
 update_issue() {
 	local GIT_HASH
 	GIT_HASH=$(git rev-parse HEAD)
-	echo -e "Raspberry Pi reference ${IMG_DATE}\nGenerated using pi-gen, https://github.com/RPi-Distro/pi-gen, ${GIT_HASH}, ${1}" > "${ROOTFS_DIR}/etc/rpi-issue"
+	echo -e "Raspberry Pi reference ${IMG_DATE}\nGenerated using ${PI_GEN}, ${PI_GEN_REPO}, ${GIT_HASH}, ${1}" > "${ROOTFS_DIR}/etc/rpi-issue"
 }
 export -f update_issue
 

--- a/scripts/common
+++ b/scripts/common
@@ -4,21 +4,22 @@ log (){
 export -f log
 
 bootstrap(){
-	local ARCH
-	ARCH=$(dpkg --print-architecture)
+	local BOOTSTRAP_CMD=debootstrap
+	local BOOTSTRAP_ARGS=()
 
 	export http_proxy=${APT_PROXY}
 
-	if [ "$ARCH" !=  "armhf" ]; then
-		local BOOTSTRAP_CMD=qemu-debootstrap
-	else
-		local BOOTSTRAP_CMD=debootstrap
+	if [ "$(dpkg --print-architecture)" !=  "armhf" ]; then
+		BOOTSTRAP_CMD=qemu-debootstrap
 	fi
 
-	capsh --drop=cap_setfcap -- "${BOOTSTRAP_CMD}" --components=main,contrib,non-free \
-		--arch armhf \
-		--keyring "${STAGE_DIR}/files/raspberrypi.gpg" \
-		"$1" "$2" "$3" || true
+	BOOTSTRAP_ARGS+=(--arch armhf)
+	BOOTSTRAP_ARGS+=(--components "main,contrib,non-free")
+	BOOTSTRAP_ARGS+=(--keyring "${STAGE_DIR}/files/raspberrypi.gpg")
+	BOOTSTRAP_ARGS+=("$@")
+
+	capsh --drop=cap_setfcap -- "${BOOTSTRAP_CMD}" "${BOOTSTRAP_ARGS[@]}" || true
+
 	if [ -d "$2/debootstrap" ]; then
 		rmdir "$2/debootstrap"
 	fi


### PR DESCRIPTION
Improve bootstrap() function in common script:

* Tidy up and simplify function code
* Allow to pass extra arguments to debootstrap, e.g. `--variant minbase`
* Preserve compatibility with existing function calls

Improve update_issue() function in common script:

* Allow to customise pi-gen script name and repository in the generated issue file
* Preserve compatibility with existing function calls

Tested a complete distro build with these changes as well, all building fine here.