### PR TITLE
Make sure unmount_image finds stale loop devices

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -56,7 +56,7 @@ unmount_image(){
 	sync
 	sleep 1
 	local LOOP_DEVICES
-	LOOP_DEVICES=$(losetup -j "${1}" | cut -f1 -d':')
+	LOOP_DEVICES=$(losetup --list | grep "$(basename "${1}")" | cut -f1 -d' ')
 	for LOOP_DEV in ${LOOP_DEVICES}; do
 		if [ -n "${LOOP_DEV}" ]; then
 			local MOUNTED_DIR


### PR DESCRIPTION
Fixes #257 #104 #193

Instead of searching by full path, which is prone to fail, read full list and grep on filename.