### PR TITLE
Fedora fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get -y update && \
     apt-get -y install \
         git vim parted \
         quilt realpath qemu-user-static debootstrap zerofree pxz zip dosfstools \
-        bsdtar libcap2-bin rsync grep udev xz-utils curl xxd file \
+        bsdtar libcap2-bin rsync grep udev xz-utils curl xxd file kmod\
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /pi-gen/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ _Tool used to create the raspberrypi.org Raspbian images_
 
 pi-gen runs on Debian based operating systems. Currently it is only supported on
 either Debian Stretch or Ubuntu Xenial and is known to have issues building on
-earlier releases of these systems.
+earlier releases of these systems. On other Linux distributions it may be possible
+to use the Docker build described below.
 
 To install the required dependencies for pi-gen you should run:
 
@@ -158,6 +159,13 @@ It is recommended to examine build.sh for finer details.
 
 ## Docker Build
 
+Docker can be used to perform the build inside a container. This partially isolates
+the build from the host system, and allows using the script on non-debian based
+systems (e.g. Fedora Linux). The isolate is not complete due to the need to use
+some kernel level services for arm emulation (binfmt) and loop devices (losetup).
+
+To build:
+
 ```bash
 vi config         # Edit your config file. See above.
 ./build-docker.sh
@@ -171,6 +179,12 @@ continue:
 
 ```bash
 CONTINUE=1 ./build-docker.sh
+```
+
+To examine the container after a failure you can enter a shell within it using:
+
+```bash
+sudo docker run -it --privileged --volumes-from=pigen_work pi-gen /bin/bash
 ```
 
 After successful build, the build container is by default removed. This may be undesired when making incremental changes to a customized build. To prevent the build script from remove the container add

--- a/depends
+++ b/depends
@@ -15,3 +15,4 @@ curl
 xxd
 file
 git
+lsmod:kmod

--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -66,4 +66,5 @@ mount -v "$ROOT_DEV" "${ROOTFS_DIR}" -t ext4
 mkdir -p "${ROOTFS_DIR}/boot"
 mount -v "$BOOT_DEV" "${ROOTFS_DIR}/boot" -t vfat
 
-rsync -aHAXx --exclude var/cache/apt/archives "${EXPORT_ROOTFS_DIR}/" "${ROOTFS_DIR}/"
+rsync -aHAXx --exclude /var/cache/apt/archives --exclude /boot "${EXPORT_ROOTFS_DIR}/" "${ROOTFS_DIR}/"
+rsync -rtx "${EXPORT_ROOTFS_DIR}/boot/" "${ROOTFS_DIR}/boot/"

--- a/scripts/dependencies_check
+++ b/scripts/dependencies_check
@@ -27,4 +27,13 @@ dependencies_check()
 		echo "$missing"
 		false
 	fi
+
+
+	if ! lsmod | grep binfmt_misc >/dev/null
+	then
+		echo "Module binfmt_misc not loaded in host"
+		echo "Please run:"
+		echo "  sudo modprobe binfmt_misc"
+		exit 1
+	fi
 }


### PR DESCRIPTION
While testing on fedora I made a few fixes (also tested on an Ubuntu host), on top of #258 #259

5f3ddb2 Check binfmt_misc module is loaded
Gives a friendlier message when binfmt_misc is not enabled

1c9df06 Use different rsync options for boot and root
Fixes #260

fc3d814 README.md: Add more info on Docker