### PR TITLE
Moved git-hash determination to passed in build variable

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -52,6 +52,9 @@ if [ -z "${IMG_NAME}" ]; then
 exit 1
 fi
 
+# Ensure the Git Hash is recorded before entering the docker container
+GIT_HASH=${GIT_HASH:-"$(git rev-parse HEAD)"}
+
 CONTAINER_EXISTS=$(${DOCKER} ps -a --filter name="${CONTAINER_NAME}" -q)
 CONTAINER_RUNNING=$(${DOCKER} ps --filter name="${CONTAINER_NAME}" -q)
 if [ "${CONTAINER_RUNNING}" != "" ]; then
@@ -73,6 +76,7 @@ if [ "${CONTAINER_EXISTS}" != "" ]; then
 	trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${CONTAINER_NAME}_cont' SIGINT SIGTERM
 	time ${DOCKER} run --rm --privileged \
 		--volume "${CONFIG_FILE}":/config:ro \
+		-e "GIT_HASH=${GIT_HASH}" \
 		--volumes-from="${CONTAINER_NAME}" --name "${CONTAINER_NAME}_cont" \
 		pi-gen \
 		bash -e -o pipefail -c "dpkg-reconfigure qemu-user-static &&
@@ -83,6 +87,7 @@ else
 	trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${CONTAINER_NAME}' SIGINT SIGTERM
 	time ${DOCKER} run --name "${CONTAINER_NAME}" --privileged \
 		--volume "${CONFIG_FILE}":/config:ro \
+		-e "GIT_HASH=${GIT_HASH}" \
 		pi-gen \
 		bash -e -o pipefail -c "dpkg-reconfigure qemu-user-static &&
 	cd /pi-gen; ./build.sh ${BUILD_OPTS} &&

--- a/build.sh
+++ b/build.sh
@@ -168,6 +168,8 @@ export WPA_PASSWORD
 export WPA_COUNTRY
 export ENABLE_SSH="${ENABLE_SSH:-0}"
 
+export GIT_HASH=${GIT_HASH:-"$(git rev-parse HEAD)"}
+
 export BASE_DIR
 
 export CLEAN

--- a/scripts/common
+++ b/scripts/common
@@ -94,9 +94,6 @@ on_chroot() {
 export -f on_chroot
 
 update_issue() {
-	local GIT_HASH
-	GIT_HASH=$(git rev-parse HEAD)
 	echo -e "Raspberry Pi reference ${IMG_DATE}\nGenerated using ${PI_GEN}, ${PI_GEN_REPO}, ${GIT_HASH}, ${1}" > "${ROOTFS_DIR}/etc/rpi-issue"
 }
 export -f update_issue
-


### PR DESCRIPTION
This fixes trying to retrieve the HEAD commit hash during the build stages themselves which can fail under certain circumstances using docker in a git submodule. (See https://github.com/RPi-Distro/pi-gen/issues/180#issuecomment-480003387).