### PR TITLE
Silence shellcheck warnings

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -15,6 +15,7 @@ fi
 set -e
 
 if [ -f config ]; then
+	# shellcheck disable=SC1091
 	source config
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -203,8 +203,8 @@ if [[ ! "$FIRST_USER_NAME" =~ ^[a-z][-a-z0-9_]*$ ]]; then
 	exit 1
 fi
 
-if [[ -n "${APT_PROXY}" ]] && ! curl --silent ${APT_PROXY} >/dev/null ; then
-	echo "Could not reach APT_PROXY server:" ${APT_PROXY}
+if [[ -n "${APT_PROXY}" ]] && ! curl --silent "${APT_PROXY}" >/dev/null ; then
+	echo "Could not reach APT_PROXY server: ${APT_PROXY}"
 	exit 1
 fi
 


### PR DESCRIPTION
* SC1091: the `config` file might not be present, which is normal.
* SC2086: Double quote to prevent globbing and word splitting.

Tested clean output using: `find -name "*.sh" -exec shellcheck -x {} \;`