### PR TITLE
Update Dockerfile base image to Debian Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
With the Qemu version shipped with Debian Stretch, the `man-db` package being installed for Buster in the image triggers many of these errors:

    qemu: Unsupported syscall: 383

This is a manifestation of the following bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=891109

This is resolved in the current Qemu version shipped with Debian Buster.