### PR TITLE
64 bit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,9 @@ follows:
 
 # Troubleshooting
 
+## `64 Bit Systems`
+Please note there is currently an issue when compiling with a 64 Bit OS. See https://github.com/RPi-Distro/pi-gen/issues/271
+
 ## `binfmt_misc`
 
 Linux is able execute binaries from other architectures, meaning that it should be


### PR DESCRIPTION
Added a handy message to make it clear that compiling on a 64 bit OS is causing issues. After spending over an hour of troubleshooting think it should be made clearer as it'll affect quite a few users.