### PR TITLE
Fix build.sh to run dependencies_check prior to using curl.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -197,6 +197,8 @@ source "${SCRIPT_DIR}/common"
 # shellcheck source=scripts/dependencies_check
 source "${SCRIPT_DIR}/dependencies_check"
 
+dependencies_check "${BASE_DIR}/depends"
+
 #check username is valid
 if [[ ! "$FIRST_USER_NAME" =~ ^[a-z][-a-z0-9_]*$ ]]; then
 	echo "Invalid FIRST_USER_NAME: $FIRST_USER_NAME"
@@ -207,8 +209,6 @@ if [[ -n "${APT_PROXY}" ]] && ! curl --silent "${APT_PROXY}" >/dev/null ; then
 	echo "Could not reach APT_PROXY server: ${APT_PROXY}"
 	exit 1
 fi
-
-dependencies_check "${BASE_DIR}/depends"
 
 mkdir -p "${WORK_DIR}"
 log "Begin ${BASE_DIR}"


### PR DESCRIPTION
If `${APT_PROXY}` is set, then the build script uses `curl` to see if it can connect to it.

Currently, if curl is not installed, then the script bombs out such as:
```
./build.sh: line 206: curl: command not found
Could not reach APT_PROXY server: http://localhost:3142/
```
Of course, the reason the server couldn't be reached is because curl isn't installed - not due to any network issue.

This pull request simply moves the `dependencies_check` call prior to the use of curl. This way if curl is not installed, then the script exits gracefully with the instructions to install curl.

I believe this is a low priority fix. For most users, this will be a cosmetic change, since they'd be able to interpret the error sequence anyway.