### PR TITLE
Remove obsolete IPv6 turnoff

### DIFF
--- a/stage1/02-net-tweaks/00-run.sh
+++ b/stage1/02-net-tweaks/00-run.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 
-install -m 644 files/ipv6.conf "${ROOTFS_DIR}/etc/modprobe.d/ipv6.conf"
 install -m 644 files/hostname "${ROOTFS_DIR}/etc/hostname"
 
 ln -sf /dev/null "${ROOTFS_DIR}/etc/systemd/network/99-default.link"

--- a/stage1/02-net-tweaks/files/ipv6.conf
+++ b/stage1/02-net-tweaks/files/ipv6.conf
@@ -1,3 +1,0 @@
-# Don't load ipv6 by default
-alias net-pf-10 off
-#alias ipv6 off


### PR DESCRIPTION
Turning off IPv6 by aliasing `net-pf-10` to `off` does not work anymore.
Also, turning off IPv6 on system level breaks apps depending on IPv6
loopback or IPv6 link-local addresssing and creates issues in both
dual-stack and IPv6-only environments.

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>