### PR TITLE
build-docker.sh does not assume PWD=<repo root>

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -13,24 +13,30 @@ if ! ${DOCKER} ps >/dev/null; then
 	exit 1
 fi
 
-CONFIG_FILE="${DIR}/config"
-if [ -f "${CONFIG_FILE}" ]; then
-	# shellcheck disable=SC1091
-	source "${CONFIG_FILE}"
+CONFIG_FILE=""
+if [ -f "${DIR}/config" ]; then
+	CONFIG_FILE="${DIR}/config"
 fi
 
 while getopts "c:" flag
 do
 	case "${flag}" in
 		c)
-			# shellcheck disable=SC1090
-			source "${OPTARG}"
 			CONFIG_FILE="${OPTARG}"
 			;;
 		*)
 			;;
 	esac
 done
+
+# Ensure that the confguration file is present
+if test -z "${CONFIG_FILE}"; then
+	echo "Configuration file need to be present in '${DIR}/config' or path passed as parameter"
+	exit 1
+else
+	# shellcheck disable=SC1090
+	source "${CONFIG_FILE}"
+fi
 
 CONTAINER_NAME=${CONTAINER_NAME:-pigen_work}
 CONTINUE=${CONTINUE:-0}

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 BUILD_OPTS="$*"
 
@@ -61,7 +62,7 @@ if [ "${CONTAINER_EXISTS}" != "" ] && [ "${CONTINUE}" != "1" ]; then
 	exit 1
 fi
 
-${DOCKER} build -t pi-gen .
+${DOCKER} build -t pi-gen "${DIR}"
 if [ "${CONTAINER_EXISTS}" != "" ]; then
 	trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${CONTAINER_NAME}_cont' SIGINT SIGTERM
 	time ${DOCKER} run --rm --privileged \


### PR DESCRIPTION
The `build-docker.sh` script should not assume that is executed from the repository root especially as the assumption is only used to build the docker-container.

Allowing the script to "auto-determine" its directory allows users to create configurations on their desired directories and then run something like `bash ${RPi-Distro/pi-gen/build-docker.sh} -c config`.
