### PR TITLE
Revert "stage2: Add apt-transport-https"

### DIFF
--- a/stage2/01-sys-tweaks/00-packages
+++ b/stage2/01-sys-tweaks/00-packages
@@ -14,7 +14,6 @@ raspberrypi-sys-mods
 pi-bluetooth
 apt-listchanges
 usb-modeswitch
-apt-transport-https
 libpam-chksshpwd
 rpi-update
 libmtp-runtime


### PR DESCRIPTION
This reverts commit 1806504983024db6cf00935e20abcfd3295ab248.

In Buster, APT has built‐in support for HTTPS repos (since version 1.5). The [ca-certificates](https://packages.debian.org/buster/ca-certificates) package is already included in the modified file, so this commit shouldn’t break anything.

See also: https://packages.debian.org/buster/apt-transport-https