### PR TITLE
Ensure that the configuration file is an absolute path in Docker build

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -30,6 +30,9 @@ do
 	esac
 done
 
+# Ensure that the configuration file is an absolute path
+CONFIG_FILE=$(realpath -s "$CONFIG_FILE")
+
 # Ensure that the confguration file is present
 if test -z "${CONFIG_FILE}"; then
 	echo "Configuration file need to be present in '${DIR}/config' or path passed as parameter"

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -73,7 +73,7 @@ if [ "${CONTAINER_EXISTS}" != "" ]; then
 		--volumes-from="${CONTAINER_NAME}" --name "${CONTAINER_NAME}_cont" \
 		pi-gen \
 		bash -e -o pipefail -c "dpkg-reconfigure qemu-user-static &&
-	cd /pi-gen; ./build.sh ${BUILD_OPTS} ;
+	cd /pi-gen; ./build.sh ${BUILD_OPTS} &&
 	rsync -av work/*/build.log deploy/" &
 	wait "$!"
 else

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -63,7 +63,7 @@ if [ "${CONTAINER_EXISTS}" != "" ] && [ "${CONTINUE}" != "1" ]; then
 fi
 
 # Modify original build-options to allow config file to be mounted in the docker container
-BUILD_OPTS="$(echo ${BUILD_OPTS:-} | sed -E 's@\-c\s?([^ ]+)@-c /config@')"
+BUILD_OPTS="$(echo "${BUILD_OPTS:-}" | sed -E 's@\-c\s?([^ ]+)@-c /config@')"
 
 ${DOCKER} build -t pi-gen "${DIR}"
 if [ "${CONTAINER_EXISTS}" != "" ]; then


### PR DESCRIPTION
PR #302 broke the Docker build script as previously documented. See below.

The specific problem is in commit 2ddd7c1c, where the passed config file (using the `-c` option) is now mounted inside the container using the `--volume src:dest:opt` Docker option.

If you pass a relative-path config file (like in the *non-working* example you gave in the PR description) you get this error after building the Docker image and starting the `pi-gen` build:

    bash ${RPi-Distro/pi-gen/build-docker.sh} -c config
    (...)
    ./build.sh: line 137: source: /config: is a directory

The problem is that Docker requires absolute paths for mounting single files inside the container, otherwise it silently tries to mount a volume name instead as an empty directory. Therefore the Docker build no longer works with the following invocation forms (relative config-paths):

    ./build-docker.sh -c myconfig
    /path/to/build-docker.sh -c myconfig   # also doesn't work

And instead the Docker build must now be invoked using absolute config-paths:

    ./build-docker.sh -c /path/to/myconfig   # works
    ./build-docker.sh -c $PWD/myconfig   # alternative
    /path/to/build-docker.sh -c /path/to/myconfig   # another alternative

~This is not really fixable because is just the way Docker works when using `--volume`.~

~Instead, this PR improves the documentation overall and adds how `build-docker.sh` works currently.~

**Update:** Fixed now using `realpath` (see commit 4fd20bd) that preserves old behaviour.

Also I'm silencing a new shellcheck warning and slightly fixing a missing `&&` in a Docker pipeline.