### PR TITLE
Make build_docker.sh portable again

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -63,7 +63,7 @@ if [ "${CONTAINER_EXISTS}" != "" ] && [ "${CONTINUE}" != "1" ]; then
 fi
 
 # Modify original build-options to allow config file to be mounted in the docker container
-BUILD_OPTS="$(echo ${BUILD_OPTS:-} | sed -r 's@\-c\s?([^ ]+)@-c /config@')"
+BUILD_OPTS="$(echo ${BUILD_OPTS:-} | sed -E 's@\-c\s?([^ ]+)@-c /config@')"
 
 ${DOCKER} build -t pi-gen "${DIR}"
 if [ "${CONTAINER_EXISTS}" != "" ]; then


### PR DESCRIPTION
Last commit made the script break on macOS.

From `man sed` (On Linux):

```
       -E, -r, --regexp-extended

              use extended regular expressions in the script (for portability use POSIX -E).
```