### PR TITLE
Update config.txt to replace lirc-rpi with gpio-ir

### DIFF
--- a/stage1/00-boot-files/files/config.txt
+++ b/stage1/00-boot-files/files/config.txt
@@ -47,8 +47,9 @@
 #dtparam=i2s=on
 #dtparam=spi=on
 
-# Uncomment this to enable the lirc-rpi module
-#dtoverlay=lirc-rpi
+# Uncomment this to enable infrared communication.
+#dtoverlay=gpio-ir,gpio_pin=17
+#dtoverlay=gpio-ir-tx,gpio_pin=18
 
 # Additional overlays and parameters are documented /boot/overlays/README
 


### PR DESCRIPTION
The example for enabling IR transmission in `/boot/config.txt` is still using the deprecated `lirc-rpi` overlay. 
The documentation in `/boot/overlays/README` indicates that this overlay has been deprecated in favor of `gpio-ir` / `gpio-ir-tx`.

This updates the actual config.txt to suggest `gpio-ir` instead of `lirc-rpi`.