### PR TITLE
Customize root access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ SKIP_IMAGES
 .pc
 *-pc
 apt-cacher-ng/
+*.orig

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ The following environment variables are supported:
 
    Password for the first user
 
+ * `ROOT_PUBLIC_KEY` (Default: "")
+
+   If set this public key will be added to the authorized_keys of the root user.
+
  * `WPA_ESSID`, `WPA_PASSWORD` and `WPA_COUNTRY` (Default: unset)
 
    If these are set, they are use to configure `wpa_supplicant.conf`, so that the Raspberry Pi can automatically connect to a wifi network on first boot. If `WPA_ESSID` is set and `WPA_PASSWORD` is unset an unprotected wifi network will be configured. If set, `WPA_PASSWORD` must be between 8 and 63 characters.

--- a/build.sh
+++ b/build.sh
@@ -166,7 +166,9 @@ export TARGET_HOSTNAME=${TARGET_HOSTNAME:-raspberrypi}
 
 export FIRST_USER_NAME=${FIRST_USER_NAME:-pi}
 export FIRST_USER_PASS=${FIRST_USER_PASS:-raspberry}
+export ROOT_PUBLIC_KEY="${ROOT_PUBLIC_KEY}"
 export RELEASE=${RELEASE:-buster}
+
 export WPA_ESSID
 export WPA_PASSWORD
 export WPA_COUNTRY

--- a/stage2/01-sys-tweaks/01-run.sh
+++ b/stage2/01-sys-tweaks/01-run.sh
@@ -21,6 +21,10 @@ else
 	systemctl disable ssh
 fi
 systemctl enable regenerate_ssh_host_keys
+if [ -n "${ROOT_PUBLIC_KEY}" ]; then
+	mkdir -p /root/.ssh
+	echo "${ROOT_PUBLIC_KEY}" >> /root/.ssh/authorized_keys
+fi
 EOF
 
 if [ "${USE_QEMU}" = "1" ]; then


### PR DESCRIPTION
This request contains a way to add a public key to the root user to access it via ssh (usefull for first configuration in server mode).

With this you just need to add in the config file the key ROOT_PUBLIC_KEY with your public key as value.

Next step: disabling ssh authentication with password for root user to improve security.