### PR TITLE
hostname is now configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following environment variables are supported:
    be built and cached.  Note, `WORK_DIR` stores a complete copy of the target
    system for each build stage, amounting to tens of gigabytes in the case of
    Raspbian.
-   
+
    **CAUTION**: If your working directory is on an NTFS partition you probably won't be able to build. Make sure this is a proper Linux filesystem.
 
  * `DEPLOY_DIR`  (Default: `"$BASE_DIR/deploy"`)
@@ -81,6 +81,10 @@ The following environment variables are supported:
  * `LOCALE_DEFAULT` (Default: "en_GB.UTF-8" )
 
    Default system locale.
+
+ * `HOSTNAME` (Default: "raspberrypi" )
+
+   Setting the hostname to the specified value.
 
  * `KEYBOARD_KEYMAP` (Default: "gb" )
 

--- a/build.sh
+++ b/build.sh
@@ -161,6 +161,8 @@ export DEPLOY_DIR=${DEPLOY_DIR:-"${BASE_DIR}/deploy"}
 export DEPLOY_ZIP="${DEPLOY_ZIP:-1}"
 export LOG_FILE="${WORK_DIR}/build.log"
 
+export HOSTNAME=${HOSTNAME:-raspberrypi}
+
 export FIRST_USER_NAME=${FIRST_USER_NAME:-pi}
 export FIRST_USER_PASS=${FIRST_USER_PASS:-raspberry}
 export WPA_ESSID

--- a/stage1/02-net-tweaks/00-run.sh
+++ b/stage1/02-net-tweaks/00-run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
-install -m 644 files/hostname "${ROOTFS_DIR}/etc/hostname"
+echo "${HOSTNAME}" > "${ROOTFS_DIR}/etc/hostname"
 
 ln -sf /dev/null "${ROOTFS_DIR}/etc/systemd/network/99-default.link"

--- a/stage1/02-net-tweaks/files/hostname
+++ b/stage1/02-net-tweaks/files/hostname
@@ -1,1 +1,0 @@
-raspberrypi


### PR DESCRIPTION
I make the hostname configurable via the config file using the HOSTNAME variable. If the HOSTNAME has not been set the default is 'raspberrypi', otherwise the hostname will be set to the specified value.