### PR TITLE
OS X does not have realpath

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -31,7 +31,9 @@ do
 done
 
 # Ensure that the configuration file is an absolute path
-CONFIG_FILE=$(realpath -s "$CONFIG_FILE")
+if test -x /usr/bin/realpath; then
+	CONFIG_FILE=$(realpath -s "$CONFIG_FILE")
+fi
 
 # Ensure that the confguration file is present
 if test -z "${CONFIG_FILE}"; then


### PR DESCRIPTION
Check that realpath is present.  OS X doesn't have realpath.  The RPi builds on Docker for Mac if you increase the VM size. I am using 256G for my image.  See the Docker for Mac preferences.