### PR TITLE
Export base directory before loading config file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -122,6 +122,7 @@ if [ "$(id -u)" != "0" ]; then
 	exit 1
 fi
 
+export BASE_DIR=${BASE_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}
 
 if [ -f config ]; then
 	# shellcheck disable=SC1091
@@ -154,7 +155,6 @@ export IMG_DATE="${IMG_DATE:-"$(date +%Y-%m-%d)"}"
 export IMG_FILENAME="${IMG_FILENAME:-"${IMG_DATE}-${IMG_NAME}"}"
 export ZIP_FILENAME="${ZIP_FILENAME:-"image_${IMG_DATE}-${IMG_NAME}"}"
 
-BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export SCRIPT_DIR="${BASE_DIR}/scripts"
 export WORK_DIR="${WORK_DIR:-"${BASE_DIR}/work/${IMG_DATE}-${IMG_NAME}"}"
 export DEPLOY_DIR=${DEPLOY_DIR:-"${BASE_DIR}/deploy"}

--- a/build.sh
+++ b/build.sh
@@ -180,8 +180,6 @@ export TIMEZONE_DEFAULT="${TIMEZONE_DEFAULT:-Europe/London}"
 
 export GIT_HASH=${GIT_HASH:-"$(git rev-parse HEAD)"}
 
-export BASE_DIR
-
 export CLEAN
 export IMG_NAME
 export APT_PROXY

--- a/build.sh
+++ b/build.sh
@@ -122,7 +122,8 @@ if [ "$(id -u)" != "0" ]; then
 	exit 1
 fi
 
-export BASE_DIR=${BASE_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}
+export BASE_DIR
 
 if [ -f config ]; then
 	# shellcheck disable=SC1091


### PR DESCRIPTION
By exporting the base directory before loading config, it is possible to use the base dir within the config file.
