### PR TITLE
Explicitly check if postrun script exists in BASE_DIR

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -247,7 +247,7 @@ for EXPORT_DIR in ${EXPORT_DIRS}; do
 	fi
 done
 
-if [ -x postrun.sh ]; then
+if [ -x ${BASE_DIR}/postrun.sh ]; then
 	log "Begin postrun.sh"
 	cd "${BASE_DIR}"
 	./postrun.sh


### PR DESCRIPTION
This ensures execution of the postrun script, even when any of the previous scripts didn't end in the base directory.