### PR TITLE
Attach to bridge network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2'
 services:
   apt-cacher-ng:
     restart: unless-stopped
+    network_mode: "bridge"
     image: sameersbn/apt-cacher-ng:latest
     ports:
     - "3142:3142"


### PR DESCRIPTION
To allow docker-build.sh access to the apt-cacher container, attach to the default network.