### PR TITLE
configure unprotected wifi when WPA_PASSWORD is unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The following environment variables are supported:
 
  * `WPA_ESSID`, `WPA_PASSWORD` and `WPA_COUNTRY` (Default: unset)
 
-   If these are set, they are use to configure `wpa_supplicant.conf`, so that the raspberry pi can automatically connect to a wifi network on first boot.
+   If these are set, they are use to configure `wpa_supplicant.conf`, so that the raspberry pi can automatically connect to a wifi network on first boot. If `WPA_ESSID` is set and `WPA_PASSWORD` is unset a unprotected wifi network will be configured.
 
  * `ENABLE_SSH` (Default: `0`)
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The following environment variables are supported:
 
  * `WPA_ESSID`, `WPA_PASSWORD` and `WPA_COUNTRY` (Default: unset)
 
-   If these are set, they are use to configure `wpa_supplicant.conf`, so that the raspberry pi can automatically connect to a wifi network on first boot. If `WPA_ESSID` is set and `WPA_PASSWORD` is unset a unprotected wifi network will be configured.
+   If these are set, they are use to configure `wpa_supplicant.conf`, so that the raspberry pi can automatically connect to a wifi network on first boot. If `WPA_ESSID` is set and `WPA_PASSWORD` is unset an unprotected wifi network will be configured.
 
  * `ENABLE_SSH` (Default: `0`)
 

--- a/stage2/02-net-tweaks/01-run.sh
+++ b/stage2/02-net-tweaks/01-run.sh
@@ -14,6 +14,14 @@ if [ -v WPA_ESSID ] && [ -v WPA_PASSWORD ]; then
 on_chroot <<EOF
 wpa_passphrase "${WPA_ESSID}" "${WPA_PASSWORD}" >> "/etc/wpa_supplicant/wpa_supplicant.conf"
 EOF
+elif [ -v WPA_ESSID ]; then
+cat >> "${ROOTFS_DIR}/etc/wpa_supplicant/wpa_supplicant.conf" << EOL
+
+network={
+	ssid="${WPA_ESSID}"
+	key_mgmt=NONE
+}
+EOL
 fi
 
 # Disable wifi on 5GHz models


### PR DESCRIPTION
Hello,

I wanted to create a Raspbian image with a configured unprotected wifi network. 

I found out that with the current code only protected wifi networks are possible to configure.

Maybe my solution can be used.

Greets,
Christian