### PR TITLE
move picraft to stage where minecraft is installed

### DIFF
--- a/stage4/00-install-packages/00-packages
+++ b/stage4/00-install-packages/00-packages
@@ -18,7 +18,6 @@ python-spidev python3-spidev
 python-twython python3-twython
 python-smbus python3-smbus
 python-flask python3-flask
-python-picraft python3-picraft
 pprompt
 piwiz
 rp-prefapps

--- a/stage5/00-install-extras/00-packages
+++ b/stage5/00-install-extras/00-packages
@@ -3,7 +3,7 @@ sonic-pi
 scratch nuscratch scratch2 scratch3
 smartsim
 
-minecraft-pi python-minecraftpi
+minecraft-pi python-minecraftpi python-picraft python3-picraft
 python-sense-emu sense-emu-tools python-sense-emu-doc
 
 wolfram-engine


### PR DESCRIPTION
Hello,

I'm not really sure about that, but for my understanding it's only necassary to install python-picraft when there is a installed minecraft.