### PR TITLE
WPA_PASSWORD length check should only occur if set

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -220,7 +220,7 @@ if [[ -n "${APT_PROXY}" ]] && ! curl --silent "${APT_PROXY}" >/dev/null ; then
 	exit 1
 fi
 
-if [[ ${#WPA_PASSWORD} -lt 8 || ${#WPA_PASSWORD} -gt 63  ]] ; then
+if [[ -n "${WPA_PASSWORD}" && ${#WPA_PASSWORD} -lt 8 || ${#WPA_PASSWORD} -gt 63  ]] ; then
 	echo "WPA_PASSWORD" must be between 8 and 63 characters
 	exit 1
 fi


### PR DESCRIPTION
Test if WPA_PASSWORD is set before check that it has a valid length.

Fixes #368 