### PR TITLE
ensure binfmt-support is installed

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -3,11 +3,23 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 BUILD_OPTS="$*"
 
-DOCKER="docker"
-
-if ! ${DOCKER} ps >/dev/null 2>&1; then
-	DOCKER="sudo docker"
+SUDO=''
+if [ $EUID != 0 ]; then
+    SUDO='sudo'
 fi
+
+function install_binfmt_support {
+    local binfmtSupport="binfmt-support"
+    if ! dpkg -s $binfmtSupport &>/dev/null; then
+        echo "please install $binfmtSupport with this command: $SUDO apt-get install $binfmtSupport"
+        exit 1
+    fi
+}
+
+install_binfmt_support
+
+DOCKER="$SUDO docker"
+
 if ! ${DOCKER} ps >/dev/null; then
 	echo "error connecting to docker:"
 	${DOCKER} ps


### PR DESCRIPTION
As is written in the README, `binfmt-support` needs to be installed for Docker:

Ref: https://github.com/RPi-Distro/pi-gen/blame/024840034e2fab7efe170a303ef726fed1314f82/README.md#L230

(This pull-request makes that explicit and checks that it holds true)