### PR TITLE
Docker: load kernelmodules: loop, binfmt_misc

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -3,11 +3,23 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 BUILD_OPTS="$*"
 
-DOCKER="docker"
-
-if ! ${DOCKER} ps >/dev/null 2>&1; then
-	DOCKER="sudo docker"
+SUDO=''
+if [ $EUID != 0 ]; then
+    SUDO='sudo'
 fi
+
+function install_binfmt_support {
+    local binfmtSupport="binfmt-support"
+    if ! dpkg -s $binfmtSupport &>/dev/null; then
+        echo "please install $binfmtSupport with this command: $SUDO apt-get install $binfmtSupport"
+        exit 1
+    fi
+}
+
+install_binfmt_support
+
+DOCKER="$SUDO docker"
+
 if ! ${DOCKER} ps >/dev/null; then
 	echo "error connecting to docker:"
 	${DOCKER} ps

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -16,7 +16,24 @@ function install_binfmt_support {
     fi
 }
 
+function load_kernelmodule {
+    local kernelMod="$1"
+    if ! $SUDO modinfo $kernelMod &>/dev/null; then
+        echo "missing this kernel modul: $kernelMod"
+        exit 1
+    else
+        if $SUDO modprobe -n --first-time $kernelMod &>/dev/null; then
+            echo "loading kernel module $kernelMod"
+            $SUDO modprobe $kernelMod
+        fi
+    fi
+}
+
 install_binfmt_support
+
+load_kernelmodule loop
+load_kernelmodule binfmt_misc
+
 
 DOCKER="$SUDO docker"
 


### PR DESCRIPTION
The `loop` kernelmodule is needed, otherwise the script `export-image/prerun.sh` fails in this line
https://github.com/RPi-Distro/pi-gen/blob/f8f3d6fe93a6709f02f63f3a203a38bcd33a0c0d/export-image/prerun.sh#L42
with the message
```
losetup: /pi-gen/work/2020-01-08-Raspbian/export-image/2020-01-08-Raspbian-lite.img: failed to set up loop device: No such file or directory
```

See also: https://github.com/RPi-Distro/pi-gen/issues/320#issuecomment-529153428

So this is a fix for #320

(I suggest you pull my previous pull-request first, in order to reduce the commits in this pull request from 2 to 1. [This pr is based on the previous one])