### PR TITLE
Fix hostname leakage from build host

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -125,6 +125,10 @@ fi
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export BASE_DIR
 
+# Make sure HOSTNAME doesn't leak in from host
+unset HOSTNAME
+export HOSTNAME
+
 if [ -f config ]; then
 	# shellcheck disable=SC1091
 	source config


### PR DESCRIPTION
Many hosts (including the docker host) set HOSTNAME in the environment,
which means that unless the HOSTNAME is explicitly set in a 'config'
that the resulting image hostname will be the build host's hostname.

We fix that by unsetting HOSTNAME prior to reading the configs and
applying defaults.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>