### PR TITLE
Allow to modify boot console (kernel cmdline)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -178,6 +178,16 @@ export KEYBOARD_LAYOUT="${KEYBOARD_LAYOUT:-English (UK)}"
 
 export TIMEZONE_DEFAULT="${TIMEZONE_DEFAULT:-Europe/London}"
 
+export HEADLESS="${HEADLESS:-0}"
+
+if [ "${HEADLESS}" != "1" ]; then
+	export CONSOLE1="${CONSOLE1:-console=serial0,115200}"
+	export CONSOLE2="${CONSOLE2:-console=tty1}"
+else
+	export CONSOLE1="${CONSOLE1:-console=tty1}"
+	export CONSOLE2="${CONSOLE2:-console=serial0,115200}"
+fi
+
 export GIT_HASH=${GIT_HASH:-"$(git rev-parse HEAD)"}
 
 export CLEAN

--- a/stage1/00-boot-files/00-run.sh
+++ b/stage1/00-boot-files/00-run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -e
 
 install -m 644 files/cmdline.txt "${ROOTFS_DIR}/boot/"
+sed -i -e "s/CONSOLE1/${CONSOLE1}/" "${ROOTFS_DIR}/boot/cmdline.txt"
+sed -i -e "s/CONSOLE2/${CONSOLE2}/" "${ROOTFS_DIR}/boot/cmdline.txt"
 install -m 644 files/config.txt "${ROOTFS_DIR}/boot/"

--- a/stage1/00-boot-files/files/cmdline.txt
+++ b/stage1/00-boot-files/files/cmdline.txt
@@ -1,1 +1,1 @@
-console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
+CONSOLE1 CONSOLE2 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait

--- a/stage2/01-sys-tweaks/00-patches/07-resize-init.diff
+++ b/stage2/01-sys-tweaks/00-patches/07-resize-init.diff
@@ -1,5 +1,0 @@
---- stage2.orig/rootfs/boot/cmdline.txt
-+++ stage2/rootfs/boot/cmdline.txt
-@@ -1 +1 @@
--console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
-+console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet init=/usr/lib/raspi-config/init_resize.sh

--- a/stage2/01-sys-tweaks/00-patches/series
+++ b/stage2/01-sys-tweaks/00-patches/series
@@ -2,4 +2,3 @@
 02-swap.diff
 04-inputrc.diff
 05-path.diff
-07-resize-init.diff

--- a/stage2/01-sys-tweaks/01-run.sh
+++ b/stage2/01-sys-tweaks/01-run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+sed -i -e 's%\(console=.\+ \)\?\(console=.\+ \)\?root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait%\1\2root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet init=/usr/lib/raspi-config/init_resize.sh%' "${ROOTFS_DIR}/boot/cmdline.txt"
+
+
 install -m 755 files/resize2fs_once	"${ROOTFS_DIR}/etc/init.d/"
 
 install -d				"${ROOTFS_DIR}/etc/systemd/system/rc-local.service.d"


### PR DESCRIPTION
For headless servers with serial console only we want to change the
order of consoles on the kernel commandline.  In addition we add
the ability to configure the kernel commandline for the arbitrary
console configurations in case the default nor headless order is
appropriate.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>