### PR TITLE
Escape POSIX shell special characters in FIRST_USER_PASS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -165,6 +165,7 @@ export LOG_FILE="${WORK_DIR}/build.log"
 export HOSTNAME=${HOSTNAME:-raspberrypi}
 
 export FIRST_USER_NAME=${FIRST_USER_NAME:-pi}
+FIRST_USER_PASS="$(printf "%q" "$FIRST_USER_PASS")"
 export FIRST_USER_PASS=${FIRST_USER_PASS:-raspberry}
 export WPA_ESSID
 export WPA_PASSWORD


### PR DESCRIPTION
When working on a feature in my own fork I saw that any string with POSIX special characters in FIRST_USER_PASS were being expanded instead of being added literally and this breaks password authentication. This would affect anyone that has pesky POSIX special characters in the password which are often included in generated passwords. Parsing FIRST_USER_PASS thru printf "%q" before exporting fixes this. This change also allows a feature in my fork to pass encrypted passwords from the build config using FIRST_USER_PASS using an added option '-e ' during the stage1 chpasswd action. This feature will also increase security for image builders so that unencrypted FIRST_USER_NAME plaintext passwords won't be stored in the build config file.