### PR TITLE
Dockerfile: use --no-install-recommends in apt-get install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM debian:buster
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -y update && \
-    apt-get -y install \
+    apt-get -y install --no-install-recommends \
         git vim parted \
         quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools \
         bsdtar libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc\
+        binfmt-support ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /pi-gen/


### PR DESCRIPTION
Saves about 40MB in docker image.