### PR TITLE
BusyBox realpath does not support -s flag, fallback to use no flags

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -32,7 +32,7 @@ done
 
 # Ensure that the configuration file is an absolute path
 if test -x /usr/bin/realpath; then
-	CONFIG_FILE=$(realpath -s "$CONFIG_FILE")
+	CONFIG_FILE=$(realpath -s "$CONFIG_FILE" || realpath "$CONFIG_FILE")
 fi
 
 # Ensure that the confguration file is present

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -41,7 +41,7 @@ if test -z "${CONFIG_FILE}"; then
 	exit 1
 else
 	# shellcheck disable=SC1090
-	source "${CONFIG_FILE}"
+	source ${CONFIG_FILE}
 fi
 
 CONTAINER_NAME=${CONTAINER_NAME:-pigen_work}


### PR DESCRIPTION
Not all `realpath` implementations support the used `-s` flag, such as the BusyBox version.

I'm using this on an Alpine based host which uses BusyBox. This patch makes the `realpath` command fall back to omit the `-s` flag on error.