### PR TITLE
Exposed RELEASE as a configurable variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ The following environment variables are supported:
    but you should use something else for a customized version.  Export files
    in stages may add suffixes to `IMG_NAME`.
 
+ * `RELEASE` (Default: buster)
+
+   The release version to build images against. Valid values are jessie, stretch
+   buster, bullseye, and testing.
+
  * `APT_PROXY` (Default: unset)
 
    If you require the use of an apt proxy, set it here.  This proxy setting

--- a/build.sh
+++ b/build.sh
@@ -166,6 +166,7 @@ export TARGET_HOSTNAME=${TARGET_HOSTNAME:-raspberrypi}
 
 export FIRST_USER_NAME=${FIRST_USER_NAME:-pi}
 export FIRST_USER_PASS=${FIRST_USER_PASS:-raspberry}
+export RELEASE=${RELEASE:-buster}
 export WPA_ESSID
 export WPA_PASSWORD
 export WPA_COUNTRY

--- a/export-noobs/00-release/00-run.sh
+++ b/export-noobs/00-release/00-run.sh
@@ -36,6 +36,7 @@ sed "${NOOBS_DIR}/partitions.json" -i -e "s|ROOT_NOM|${ROOT_NOM}|"
 sed "${NOOBS_DIR}/os.json" -i -e "s|UNRELEASED|${IMG_DATE}|"
 sed "${NOOBS_DIR}/os.json" -i -e "s|NOOBS_NAME|${NOOBS_NAME}|"
 sed "${NOOBS_DIR}/os.json" -i -e "s|NOOBS_DESCRIPTION|${NOOBS_DESCRIPTION}|"
+sed "${NOOBS_DIR}/os.json" -i -e "s|RELEASE|${RELEASE}|"
 
 sed "${NOOBS_DIR}/release_notes.txt" -i -e "s|UNRELEASED|${IMG_DATE}|"
 

--- a/export-noobs/00-release/files/os.json
+++ b/export-noobs/00-release/files/os.json
@@ -16,5 +16,5 @@
     ],
     "url": "http://www.raspbian.org/",
     "username": "pi",
-    "version": "buster"
+    "version": "RELEASE"
 }

--- a/stage0/00-configure-apt/00-run.sh
+++ b/stage0/00-configure-apt/00-run.sh
@@ -2,6 +2,8 @@
 
 install -m 644 files/sources.list "${ROOTFS_DIR}/etc/apt/"
 install -m 644 files/raspi.list "${ROOTFS_DIR}/etc/apt/sources.list.d/"
+sed -i "s/RELEASE/${RELEASE}/g" "${ROOTFS_DIR}/etc/apt/sources.list"
+sed -i "s/RELEASE/${RELEASE}/g" "${ROOTFS_DIR}/etc/apt/sources.list.d/raspi.list"
 
 if [ -n "$APT_PROXY" ]; then
 	install -m 644 files/51cache "${ROOTFS_DIR}/etc/apt/apt.conf.d/51cache"

--- a/stage0/00-configure-apt/files/raspi.list
+++ b/stage0/00-configure-apt/files/raspi.list
@@ -1,3 +1,3 @@
-deb http://archive.raspberrypi.org/debian/ buster main
+deb http://archive.raspberrypi.org/debian/ RELEASE main
 # Uncomment line below then 'apt-get update' to enable 'apt-get source'
-#deb-src http://archive.raspberrypi.org/debian/ buster main
+#deb-src http://archive.raspberrypi.org/debian/ RELEASE main

--- a/stage0/00-configure-apt/files/sources.list
+++ b/stage0/00-configure-apt/files/sources.list
@@ -1,3 +1,3 @@
-deb http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi
+deb http://raspbian.raspberrypi.org/raspbian/ RELEASE main contrib non-free rpi
 # Uncomment line below then 'apt-get update' to enable 'apt-get source'
-#deb-src http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi
+#deb-src http://raspbian.raspberrypi.org/raspbian/ RELEASE main contrib non-free rpi

--- a/stage0/prerun.sh
+++ b/stage0/prerun.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
 if [ ! -d "${ROOTFS_DIR}" ]; then
-	bootstrap buster "${ROOTFS_DIR}" http://raspbian.raspberrypi.org/raspbian/
+	bootstrap ${RELEASE} "${ROOTFS_DIR}" http://raspbian.raspberrypi.org/raspbian/
 fi


### PR DESCRIPTION
Exposed RELEASE as a configurable variable and updated README.md.  As a
bonus, there is only on place to change the release name when the next
release is stable now.