### PR TITLE
Convert paths with cygpath if available in build-docker.sh

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -44,6 +44,12 @@ else
 	source ${CONFIG_FILE}
 fi
 
+# Convert paths to DOS format under Cygwin/MSYS2
+if test -x /usr/bin/cygpath; then
+	DIR=$(cygpath -da "$DIR")
+	CONFIG_FILE=$(cygpath -da "$CONFIG_FILE")
+fi
+
 CONTAINER_NAME=${CONTAINER_NAME:-pigen_work}
 CONTINUE=${CONTINUE:-0}
 PRESERVE_CONTAINER=${PRESERVE_CONTAINER:-0}


### PR DESCRIPTION
The utility cygpath is available under Cygwin or MSYS2 which is used for "Git Bash".  These are two of the most common ways to run a shell script on Windows.

This commit updates build-docker.sh to use cygpath to convert arguments to Docker into the correct native format when running on Windows.

NB 1: converting DIR is not necessary on MSYS2 because the conversion layer does it for you when it sees that docker isn't linked to msys.  This doesn't work for CONFIG_FILE because the converter doesn't recognize the -v xx:yy:zz syntax for setting up a volume.

NB 2: I have used cygpath -d rather than cygpath -w because this gives a path without spaces or wide-characters.

