### PR TITLE
Solve the space in base path problem #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # pi-gen
 
-_Tool used to create the raspberrypi.org Raspbian images_
+_Tool used to create the PlantoScop images for the Raspberry Pi_
+
+This tool is derived from the work of the Raspbery Pi Foundation. Their repository is found on [Github](https://www.github.com/RPI-Distro/pi-gen).
 
 
 ## Dependencies
@@ -288,7 +290,7 @@ maintenance and allows for more easy customization.
 
  - **Stage 5** - The Raspbian Full image. More development
    tools, an email client, learning tools like Scratch, specialized packages
-   like sonic-pi, office productivity, etc.  
+   like sonic-pi, office productivity, etc.
 
 ### Stage specification
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -41,7 +41,7 @@ if test -z "${CONFIG_FILE}"; then
 	exit 1
 else
 	# shellcheck disable=SC1090
-	source ${CONFIG_FILE}
+	source "${CONFIG_FILE}"
 fi
 
 CONTAINER_NAME=${CONTAINER_NAME:-pigen_work}

--- a/build.sh
+++ b/build.sh
@@ -229,7 +229,10 @@ fi
 mkdir -p "${WORK_DIR}"
 log "Begin ${BASE_DIR}"
 
-STAGE_LIST=${STAGE_LIST:-${BASE_DIR}/stage*}
+SAVEIFS=$IFS
+IFS=$(echo -en "\n\b")
+
+STAGE_LIST=${STAGE_LIST:-"${BASE_DIR}"/stage*}
 
 for STAGE_DIR in $STAGE_LIST; do
 	STAGE_DIR=$(realpath "${STAGE_DIR}")
@@ -261,3 +264,5 @@ if [ -x ${BASE_DIR}/postrun.sh ]; then
 fi
 
 log "End ${BASE_DIR}"
+
+IFS=$SAVEIFS


### PR DESCRIPTION
I believe this would solve the root cause of #75. 
However, this does not solve the problem upstream with debootstrap.
Maybe a check should be added so that if there is a space in the base path, debootstrap does not fail silently. Or to recommend using the docked build script. I believe explicit errors are better than undocumented behavior because of an upstream.

If there is a space in the base path anywhere, the scripts fails to start. 
This is due to the default separator used in bash (which is a space). 
This default separator can be change by setting the variable $IFS.
In `build.sh`, the old IFS variable is saved and then replaced by 
`\n\b`. At the end of the script, the saved IFS is set back.

In `build-docker.sh`, a simple double quote was enough.