### PR TITLE
Use mkdosfs -I to be able to write to /dev/loop*

### DIFF
--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -50,7 +50,7 @@ for FEATURE in metadata_csum 64bit; do
 	    ROOT_FEATURES="^$FEATURE,$ROOT_FEATURES"
 	fi
 done
-mkdosfs -n boot -F 32 -v "$BOOT_DEV" > /dev/null
+mkdosfs -I -n boot -F 32 -v "$BOOT_DEV" > /dev/null
 mkfs.ext4 -L rootfs -O "$ROOT_FEATURES" "$ROOT_DEV" > /dev/null
 
 mount -v "$ROOT_DEV" "${ROOTFS_DIR}" -t ext4


### PR DESCRIPTION
From mkdosfs' manual:
"It is typical for fixed disk devices to be partitioned so, by default,
you are not permitted to create a filesystem across the entire device.
mkfs.fat will complain and tell you that it refuses to work."

On some systems, mkdosfs identifies the loop device is an entire disk.
The -I flag makes mkdosfs work properly on such systems.