### PR TITLE
Replace bsdtar with libarchive-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
         git vim parted \
         quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools \
-        bsdtar libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc\
+        libarchive-tools libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc\
         binfmt-support ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To install the required dependencies for pi-gen you should run:
 
 ```bash
 apt-get install coreutils quilt parted qemu-user-static debootstrap zerofree zip \
-dosfstools bsdtar libcap2-bin grep rsync xz-utils file git curl bc
+dosfstools libarchive-tools libcap2-bin grep rsync xz-utils file git curl bc
 ```
 
 The file `depends` contains a list of tools needed.  The format of this

--- a/depends
+++ b/depends
@@ -7,7 +7,7 @@ zerofree
 zip
 mkdosfs:dosfstools
 capsh:libcap2-bin
-bsdtar
+libarchive-tools
 grep
 rsync
 xz:xz-utils


### PR DESCRIPTION
bsdtar has been included in libarchive-tools post Ubuntu 16.04 (Xenial)