### PR TITLE
Adds RASPBIAN_MIRROR and DEBIAN_MIRROR config items

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ The following environment variables are supported:
    The release version to build images against. Valid values are jessie, stretch
    buster, bullseye, and testing.
 
+ * `BOOTSTRAP_URL` (Default: http://raspbian.raspberrypi.org/raspbian/)
+
+   The apt source to use as the source for the stage0 Debian bootstrap process.
+
+   Public mirrors may be found at https://www.raspbian.org/RaspbianMirrors
+
+ * `CUSTOM_LIST` (Default: unset)
+
+   Set this variable to a path to a file to install as the
+   `/etc/apt/sources.list` file.
+
+   If this variable is set, the standard list files as provided with `pi-gen`
+   are ignored.
+
+ * `CUSTOM_LIST_DIR` (Default: unset)
+
+   Set this variable to a path to a directory holding list files to be
+   installed to the `/etc/apt/sources.list.d` directory.
+
+   If this variable is set, the standard list files as provided with `pi-gen`
+   are ignored.
+
  * `APT_PROXY` (Default: unset)
 
    If you require the use of an apt proxy, set it here.  This proxy setting

--- a/build.sh
+++ b/build.sh
@@ -164,6 +164,10 @@ export LOG_FILE="${WORK_DIR}/build.log"
 
 export TARGET_HOSTNAME=${TARGET_HOSTNAME:-raspberrypi}
 
+export BOOTSTRAP_URL=${BOOTSTRAP_URL:-"http://raspbian.raspberrypi.org/raspbian/"}
+export CUSTOM_LIST=${CUSTOM_LIST:-}
+export CUSTOM_LIST_DIR=${CUSTOM_LIST_DIR:-}
+
 export FIRST_USER_NAME=${FIRST_USER_NAME:-pi}
 export FIRST_USER_PASS=${FIRST_USER_PASS:-raspberry}
 export RELEASE=${RELEASE:-buster}

--- a/stage0/00-configure-apt/00-run.sh
+++ b/stage0/00-configure-apt/00-run.sh
@@ -1,9 +1,38 @@
 #!/bin/bash -e
 
-install -m 644 files/sources.list "${ROOTFS_DIR}/etc/apt/"
-install -m 644 files/raspi.list "${ROOTFS_DIR}/etc/apt/sources.list.d/"
-sed -i "s/RELEASE/${RELEASE}/g" "${ROOTFS_DIR}/etc/apt/sources.list"
-sed -i "s/RELEASE/${RELEASE}/g" "${ROOTFS_DIR}/etc/apt/sources.list.d/raspi.list"
+# if either CUSTOM_LIST or CUSTOM_LIST_DIR is set, then install sources from there
+set -x
+
+echo "$CUSTOM_LIST"
+echo "$CUSTOM_LIST_DIR"
+
+if [ -n "$CUSTOM_LIST" -o -n "$CUSTOM_LIST_DIR" ]; then
+    if [ -n "$CUSTOM_LIST" ]; then
+        if [ -f "$CUSTOM_LIST" ]; then
+            install -m 644 "$CUSTOM_LIST" "${ROOTFS_DIR}/etc/apt/sources.list" || exit 1
+        else
+            echo "$CUSTOM_LIST cannot be found"; exit 1
+        fi
+    fi
+    if [ -n "$CUSTOM_LIST_DIR" ]; then
+        if [ -d "$CUSTOM_LIST_DIR" ]; then
+            install -m 644 "$CUSTOM_LIST_DIR"/* "${ROOTFS_DIR}/etc/apt/sources.list.d/" || exit 1
+        else
+            echo "$CUSTOM_LIST_DIR cannot be found"; exit 1
+        fi
+    fi
+
+# otherwise, use the standard sources as provided by pi-gen
+else
+    install -m 644 files/sources.list "${ROOTFS_DIR}/etc/apt/"
+    install -m 644 files/raspi.list "${ROOTFS_DIR}/etc/apt/sources.list.d/"
+fi
+
+# replace 'RELEASE' with "$RELEASE" in all .list files
+if [ -f "${ROOTFS_DIR}/etc/apt/sources.list" ]; then
+    sed -i "s/RELEASE/${RELEASE}/g" "${ROOTFS_DIR}/etc/apt/sources.list"
+fi
+find "${ROOTFS_DIR}/etc/apt/sources.list.d/" -type f -exec sed -i "s/RELEASE/${RELEASE}/g" {} \;
 
 if [ -n "$APT_PROXY" ]; then
 	install -m 644 files/51cache "${ROOTFS_DIR}/etc/apt/apt.conf.d/51cache"

--- a/stage0/prerun.sh
+++ b/stage0/prerun.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
 if [ ! -d "${ROOTFS_DIR}" ]; then
-	bootstrap ${RELEASE} "${ROOTFS_DIR}" http://raspbian.raspberrypi.org/raspbian/
+	bootstrap ${RELEASE} "${ROOTFS_DIR}" "${BOOTSTRAP_URL}"
 fi


### PR DESCRIPTION
This pull request closes #444 .

It adds RASPBIAN_MIRROR and DEBIAN_MIRROR config items in order to allow custom mirrors to be used rather than just hardcoding the Raspberry Pi Foundation repositories.