### PR TITLE
workaround build failure on AWS M6g instances

### DIFF
--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -39,8 +39,19 @@ BOOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 4 | tr -d B)
 ROOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 2 | tr -d B)
 ROOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 4 | tr -d B)
 
-BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}")
-ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}")
+
+echo "Mounting BOOT_DEV..."
+until BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}"); do
+	echo "Error in losetup for BOOT_DEV.  Retrying..."
+	sleep 5
+done
+
+echo "Mounting ROOT_DEV..."
+until ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}"); do
+	echo "Error in losetup for ROOT_DEV.  Retrying..."
+	sleep 5
+done
+
 echo "/boot: offset $BOOT_OFFSET, length $BOOT_LENGTH"
 echo "/:     offset $ROOT_OFFSET, length $ROOT_LENGTH"
 

--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -39,17 +39,30 @@ BOOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 4 | tr -d B)
 ROOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 2 | tr -d B)
 ROOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 4 | tr -d B)
 
-
 echo "Mounting BOOT_DEV..."
+cnt=0
 until BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}"); do
-	echo "Error in losetup for BOOT_DEV.  Retrying..."
-	sleep 5
+	if [ $cnt -lt 5 ]; then
+		cnt=$((cnt + 1))
+		echo "Error in losetup for BOOT_DEV.  Retrying..."
+		sleep 5
+	else
+		echo "ERROR: losetup for BOOT_DEV failed; exiting"
+		exit 1
+	fi
 done
 
 echo "Mounting ROOT_DEV..."
+cnt=0
 until ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}"); do
-	echo "Error in losetup for ROOT_DEV.  Retrying..."
-	sleep 5
+	if [ $cnt -lt 5 ]; then
+		cnt=$((cnt + 1))
+		echo "Error in losetup for ROOT_DEV.  Retrying..."
+		sleep 5
+	else
+		echo "ERROR: losetup for ROOT_DEV failed; exiting"
+		exit 1
+	fi
 done
 
 echo "/boot: offset $BOOT_OFFSET, length $BOOT_LENGTH"

--- a/export-noobs/prerun.sh
+++ b/export-noobs/prerun.sh
@@ -16,18 +16,31 @@ BOOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 4 | tr -d B)
 ROOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 2 | tr -d B)
 ROOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 4 | tr -d B)
 
-
 echo "Mounting BOOT_DEV..."
+cnt=0
 until BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}"); do
-	echo "Error in losetup for BOOT_DEV.  Retrying..."
-	sleep 5
+	if [ $cnt -lt 5 ]; then
+		cnt=$((cnt + 1))
+		echo "Error in losetup for BOOT_DEV.  Retrying..."
+		sleep 5
+	else
+		echo "ERROR: losetup for BOOT_DEV failed; exiting"
+		exit 1
+	fi
 done
 
 echo "Mounting ROOT_DEV..."
+cnt=0
 until ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}"); do
-	echo "Error in losetup for ROOT_DEV.  Retrying..."
-	sleep 5
-done 
+	if [ $cnt -lt 5 ]; then
+		cnt=$((cnt + 1))
+		echo "Error in losetup for ROOT_DEV.  Retrying..."
+		sleep 5
+	else
+		echo "ERROR: losetup for ROOT_DEV failed; exiting"
+		exit 1
+	fi
+done
 
 echo "/boot: offset $BOOT_OFFSET, length $BOOT_LENGTH"
 echo "/:     offset $ROOT_OFFSET, length $ROOT_LENGTH"

--- a/export-noobs/prerun.sh
+++ b/export-noobs/prerun.sh
@@ -16,8 +16,19 @@ BOOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 4 | tr -d B)
 ROOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 2 | tr -d B)
 ROOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 4 | tr -d B)
 
-BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}")
-ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}")
+
+echo "Mounting BOOT_DEV..."
+until BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}"); do
+	echo "Error in losetup for BOOT_DEV.  Retrying..."
+	sleep 5
+done
+
+echo "Mounting ROOT_DEV..."
+until ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}"); do
+	echo "Error in losetup for ROOT_DEV.  Retrying..."
+	sleep 5
+done 
+
 echo "/boot: offset $BOOT_OFFSET, length $BOOT_LENGTH"
 echo "/:     offset $ROOT_OFFSET, length $ROOT_LENGTH"
 


### PR DESCRIPTION
Build was failing for me on AWS M6g Arm instance, apparently the faster CPU triggers a race condition. This change (suggested by jtc42 here: RPi-Distro/pi-gen#358 ) introduces a wait/retry loop to work around the failure.