### PR TITLE
docker-ce 19.03 requires mknod capability to use losetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The following environment variables are supported:
 
  * `TIMEZONE_DEFAULT` (Default: "Europe/London" )
 
-   Default keyboard layout.
+   Default timezone.
 
    To get the current value from a running system, look in
    `/etc/timezone`.

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -86,7 +86,8 @@ ${DOCKER} build --build-arg BASE_IMAGE=${BASE_IMAGE} -t pi-gen "${DIR}"
 
 if [ "${CONTAINER_EXISTS}" != "" ]; then
 	trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${CONTAINER_NAME}_cont' SIGINT SIGTERM
-	time ${DOCKER} run --rm --privileged \
+	time ${DOCKER} run --rm --privileged=true \
+		--cap-add=MKNOD \
 		--volume "${CONFIG_FILE}":/config:ro \
 		-e "GIT_HASH=${GIT_HASH}" \
 		--volumes-from="${CONTAINER_NAME}" --name "${CONTAINER_NAME}_cont" \
@@ -97,7 +98,8 @@ if [ "${CONTAINER_EXISTS}" != "" ]; then
 	wait "$!"
 else
 	trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${CONTAINER_NAME}' SIGINT SIGTERM
-	time ${DOCKER} run --name "${CONTAINER_NAME}" --privileged \
+	time ${DOCKER} run --name "${CONTAINER_NAME}" --privileged=true \
+		--cap-add=MKNOD \
 		--volume "${CONFIG_FILE}":/config:ro \
 		-e "GIT_HASH=${GIT_HASH}" \
 		pi-gen \


### PR DESCRIPTION
Hi, 
I have found that using docker-ce 19.03 I need to add --cap-add=MKNOD in order to have correct usage for loop device.
Without --cap-add=MKNOD loop device setup failed.
