### PR TITLE
Adds call to mknod if loop dev does not exist after call to `losetup -f`

### DIFF
--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -39,9 +39,16 @@ BOOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 4 | tr -d B)
 ROOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 2 | tr -d B)
 ROOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 4 | tr -d B)
 
+ensure_next_loopdev() {
+    local loopdev
+    loopdev="$(losetup -f)"
+    loopmaj="$(echo "$loopdev" | sed -E 's/.*[^0-9]*?([0-9]+)$/\1/')"
+    [[ -b "$loopdev" ]] || mknod "$loopdev" b 7 "$loopmaj"
+}
+
 echo "Mounting BOOT_DEV..."
 cnt=0
-until BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}"); do
+until ensure_next_loopdev && BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}"); do
 	if [ $cnt -lt 5 ]; then
 		cnt=$((cnt + 1))
 		echo "Error in losetup for BOOT_DEV.  Retrying..."
@@ -54,7 +61,7 @@ done
 
 echo "Mounting ROOT_DEV..."
 cnt=0
-until ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}"); do
+until ensure_next_loopdev && ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}"); do
 	if [ $cnt -lt 5 ]; then
 		cnt=$((cnt + 1))
 		echo "Error in losetup for ROOT_DEV.  Retrying..."


### PR DESCRIPTION
This pull request closes #482.

A function called `ensure_next_loopdev` is defined which calls `losetup -f` which requests a new loop device to be created if a free one does not exist already and returns the name to the device that should be then available (but is not yet claimed). Then, the function checks that the device can be seen. If not, then a call to `mknod` is made to create the loop device. This works when the container has the `--privileged` flag.

The `ensure_next_loopdev` call is made before each time a call to `losetup ... -f ... <file>` is made to best ensure that when that call is made, a loop device is available. This implementation could fail in cases where there is another process grabbing the requested loop device between calls to `losetup -f` in `ensure_next_loopdev` and `losetup ... -f ... <file>` (race condition). In these cases, the existing retry loop *should* help.