### PR TITLE
Added DKMS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,18 @@ If that happens go through the following steps:
 
 Now you should be able to start a new build without running into troubles again. Most of the time, especially when using Docker build, you will only need no. 3 to get everything up and running again. 
 
+# Regarding DKMS support
+
+pi-gen support DKMS compilation in packages, provided the package postinst script is properly configured.  Pi-gen captures the kernel versions when they are first included in the pi-gen build.  These are stored in the environment variable `DKMS_VERSIONS` prefixed by '-k'.  Fore example if pi-gen is building kernels 5.10.11+, 5.10.11-v7+, and 5.10.11.-v7l+ the DKMS_VERSIONS value will be "-k 5.10.11+ -k 5.10.11-v7+ -k 5.10.11.-v7l+"
+
+The debian postinst script for the DKMS based package should be modified so that the dkms calls include the ${DKMS_VERSIONS} property.  for example:
+        
+        dkms build ${DKMS_VERSIONS} hd44780-i2c/1.0
+or
+        dkms autoinstall ${DKMS_VERSIONS}  hd44780-i2c/1.0
+
+This the DKSM_VERSIONS value tells dkms to use the versions specified with the -k option rather than asking the system what kernel it is building on.
+
 # Troubleshooting
 
 ## `64 Bit Systems`

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,21 @@
 #!/bin/bash -e
 
 # shellcheck disable=SC2119
+check_kernel_version()
+{
+	if [ -z "${DKMS_VERSIONS}" ]
+	then
+		if [ 0 -lt `find ${ROOTFS_DIR}/usr/src -name linux-headers\* -type d | wc -l` ]
+		then
+			for fn in `cat ${ROOTFS_DIR}/usr/src/linux-headers*/include/config/kernel.release`
+			do
+				export DKMS_VERSIONS="${DKMS_VERSIONS} -k ${fn}"
+			done
+		fi
+		log "====> Kernel Version: '${DKMS_VERSIONS}'"
+	fi
+}
+
 run_sub_stage()
 {
 	log "Begin ${SUB_STAGE_DIR}"
@@ -29,6 +44,7 @@ apt-get clean
 EOF
 				fi
 			fi
+			check_kernel_version
 			log "End ${SUB_STAGE_DIR}/${i}-packages-nr"
 		fi
 		if [ -f "${i}-packages" ]; then
@@ -44,6 +60,7 @@ apt-get clean
 EOF
 				fi
 			fi
+			check_kernel_version
 			log "End ${SUB_STAGE_DIR}/${i}-packages"
 		fi
 		if [ -d "${i}-patches" ]; then


### PR DESCRIPTION
Fixes #485  By adding DKMS_VERSIONS as an environment variable that can be used in DKMS based dpkg builds to build based on the kernels being installed in pi-gen and not based on the system the build is taking place on.

Documentation is added to the README