### PR TITLE
Added PIGEN_DOCKER_OPTS to  build-docker.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ fix is to ensure `binfmt-support` is installed on the host machine before
 starting the `./build-docker.sh` script (or using your own docker build
 solution).
 
+### Passing arguments to Docker
+
+When the docker image is run various required command line arguments are provided.  For example the system mounts the `/dev` directory to the `/dev` directory within the docker container.  If other arguments are required they may be specified in the PIGEN_DOCKER_OPTS environment variable.  For example setting `PIGEN_DOCKER_OPTS="--add-host foo:192.168.0.23"` will add '192.168.0.23   foo' to the `/etc/hosts` file in the container.  The `--name`
+and `--privileged` options are already set by the script and should not be redefined.
 
 ## Stage Anatomy
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -91,6 +91,7 @@ if [ "${CONTAINER_EXISTS}" != "" ]; then
 		--cap-add=ALL \
 		-v /dev:/dev \
 		-v /lib/modules:/lib/modules \
+		${PIGEN_DOCKER_OPTS} \
 		--volume "${CONFIG_FILE}":/config:ro \
 		-e "GIT_HASH=${GIT_HASH}" \
 		--volumes-from="${CONTAINER_NAME}" --name "${CONTAINER_NAME}_cont" \
@@ -105,6 +106,7 @@ else
 		--cap-add=ALL \
 		-v /dev:/dev \
 		-v /lib/modules:/lib/modules \
+		${PIGEN_DOCKER_OPTS} \
 		--volume "${CONFIG_FILE}":/config:ro \
 		-e "GIT_HASH=${GIT_HASH}" \
 		pi-gen \


### PR DESCRIPTION
fixes #520

Setting the PIGEN_DOCKER_OPTS envrionment variable with Docker parameters arguments results in those parameters being added to the Docker run command.

For example
```
export PIGEN_DOCKER_OPTS="-v /etc/apt/certs:/etc/apt/certs"
```

results in the local `/etc/apt/certs` directory being visible inside the docker container.