### PR TITLE
Fix: update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
         git vim parted \
         quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools \
-        bsdtar libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc\
+        libarchive-tools libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc\
         binfmt-support ca-certificates qemu-utils kpartx \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To install the required dependencies for `pi-gen` you should run:
 
 ```bash
 apt-get install coreutils quilt parted qemu-user-static debootstrap zerofree zip \
-dosfstools bsdtar libcap2-bin grep rsync xz-utils file git curl bc \
+dosfstools libarchive-tools libcap2-bin grep rsync xz-utils file git curl bc \
 qemu-utils kpartx
 ```
 

--- a/depends
+++ b/depends
@@ -7,7 +7,7 @@ zerofree
 zip
 mkdosfs:dosfstools
 capsh:libcap2-bin
-bsdtar
+libarchive-tools
 grep
 rsync
 xz:xz-utils

--- a/depends
+++ b/depends
@@ -7,7 +7,7 @@ zerofree
 zip
 mkdosfs:dosfstools
 capsh:libcap2-bin
-libarchive-tools
+bsdtar:libarchive-tools
 grep
 rsync
 xz:xz-utils


### PR DESCRIPTION
I've been trying to run `pi-gen` on Ubuntu-20.04 and encountered problem while installing dependencies. The tool `bsdtar` is a part of  `libarchive-tools`. I fixed the dependency name where possible. Unfortunately I don't have opportunity to test if the need to switch packagage is or will be necessary on "supported" systems.