### PR TITLE
Remove deprecated elevator key from cmdline

### DIFF
--- a/stage1/00-boot-files/files/cmdline.txt
+++ b/stage1/00-boot-files/files/cmdline.txt
@@ -1,1 +1,1 @@
-console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
+console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes rootwait


### PR DESCRIPTION
With recent kernel versions, the "deadline" I/O scheduler has been replaced with "mq-deadline", and the "elevator" kernel command line option has been deprecated in general with Linux 5.4: https://kernelnewbies.org/Linux_5.4?highlight=%28elevator%29#Block_layer

A patch in `raspberrypi-sys-mods` could be applied as well, if support for Linux <5.4 is not required. Let me know and I can add it to this PR.