### PR TITLE
Use sync mode when running 'kpartx -a'

### DIFF
--- a/scripts/qcow2_handling
+++ b/scripts/qcow2_handling
@@ -36,7 +36,7 @@ connect_blkdev() {
 	init_nbd
 	qemu-nbd --discard=unmap -c $NBD_DEV "$1"
 	sync
-	kpartx -a $NBD_DEV
+	kpartx -as $NBD_DEV
 	sync
 	CURRENT_IMAGE="$1"
 }
@@ -108,7 +108,7 @@ load_qimage() {
 254MiB,,83;
 EOF
 				sync
-				kpartx -a $NBD_DEV
+				kpartx -as $NBD_DEV
 				mkdosfs -n boot -F 32 -v $MAP_BOOT_DEV
 				mkfs.ext4 -L rootfs -O "^huge_file,^metadata_csum,^64bit" $MAP_ROOT_DEV
 				sync
@@ -123,7 +123,7 @@ EOF
 				sync
 				qemu-nbd --discard=unmap -c $NBD_DEV image-${STAGE}.qcow2
 				sync
-				kpartx -a $NBD_DEV
+				kpartx -as $NBD_DEV
 			fi
 
 			mount -v -t ext4 $MAP_ROOT_DEV "${ROOTFS_DIR}"


### PR DESCRIPTION
This is regarding #550. This enables sync mode whenever we run `kpartx -a`. This ensures that `/dev/mapper/nbdXXpX`actually exists before we try to use it. I think more recent versions of `kpartx` enable sync mode by default, but it seems the `kpartx` that gets installed in Ubuntu Xenial does not.