### PR TITLE
Add check and warning for a space presence in the base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ qemu-utils kpartx
 The file `depends` contains a list of tools needed.  The format of this
 package is `<tool>[:<debian-package>]`.
 
+## Getting started with building your images
+
+Getting started is as simple as cloning this repository on your build machine. You
+can do so with:
+
+```bash
+git clone -–depth 1 https://github.com/RPI-Distro/pi-gen.git
+```
+
+Using `--depth 1` with `git clone` will create a shallow clone, only containing
+the latest revision of the repository. Do not do this on your development machine.
+
+Also, be careful to clone the repository to a base path **NOT** containing spaces.
+This configuration is not supported by debootstrap and will lead to `pi-gen` not
+running.
+
+After cloning the repository, you can move to the next step and start configuring
+your build.
 
 ## Config
 

--- a/build.sh
+++ b/build.sh
@@ -155,6 +155,14 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $BASE_DIR = *" "* ]]; then
+	echo "There is a space in the base path of pi-gen"
+	echo "This is not a valid setup supported by debootstrap."
+	echo "Please remove the spaces, or move pi-gen directory to a base path without spaces" 1>&2
+	exit 1
+fi
+
 export BASE_DIR
 
 if [ -f config ]; then


### PR DESCRIPTION
Reopening of #417 from a different upstream repo to keep things cleaner.

This PR closes #75 with a Upstream issue reason. For now, debootstrap doesn't support spaces in path, so we just check for the presence of a space character in the base path, warn the user and exit early before trying anything.