### PR TITLE
Closes #614 by creating a `FORCE_USER_CREATION` flag to be set in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,19 @@ The following environment variables are supported:
    To get the current value from a running system, look in
    `/etc/timezone`.
 
- * `FIRST_USER_NAME` (Default: "pi" )
+ * `FIRST_USER_NAME` (Default: unset)
 
-   Username for the first user
+   Username for the first user. This user creation is not enforced unless `FORCE_USER_CREATION` is
+   also set. This is a security feature designed to prevent shipping images with a default username.
 
  * `FIRST_USER_PASS` (Default: unset)
 
    Password for the first user. If unset, the account is locked.
+
+ * `FORCE_USER_CREATION` (Default: unset)
+
+   Forces the creation of the user with the username defined in `FIRST_USER_NAME`. Please be aware
+   that this is a security risk.
 
  * `WPA_ESSID`, `WPA_PASSWORD` and `WPA_COUNTRY` (Default: unset)
 

--- a/README.md
+++ b/README.md
@@ -175,19 +175,22 @@ The following environment variables are supported:
    To get the current value from a running system, look in
    `/etc/timezone`.
 
- * `FIRST_USER_NAME` (Default: unset)
+ * `FIRST_USER_NAME` (Default: `pi`)
 
-   Username for the first user. This user creation is not enforced unless `FORCE_USER_CREATION` is
-   also set. This is a security feature designed to prevent shipping images with a default username.
+   Username for the first user. This user only exists during the image creation process. Unless
+   `DISABLE_FIRST_BOOT_USER_RENAME` is set to `1`, this user will be renamed on the first boot with
+   a name chosen by the final user. This security feature is designed to prevent shipping images
+   with a default username and help prevent malicious actors from taking over your devices.
 
  * `FIRST_USER_PASS` (Default: unset)
 
    Password for the first user. If unset, the account is locked.
 
- * `FORCE_USER_CREATION` (Default: unset)
+ * `DISABLE_FIRST_BOOT_USER_RENAME` (Default: `0`)
 
-   Forces the creation of the user with the username defined in `FIRST_USER_NAME`. Please be aware
-   that this is a security risk.
+   Disable the renaming of the first user during the first boot. This make it so `FIRST_USER_NAME`
+   stays activated. `FIRST_USER_PASS` must be set for this to work. Please be aware of the implied
+   security risk of defining a default username and password for your devices.
 
  * `WPA_ESSID`, `WPA_PASSWORD` and `WPA_COUNTRY` (Default: unset)
 

--- a/build.sh
+++ b/build.sh
@@ -225,6 +225,7 @@ export TARGET_HOSTNAME=${TARGET_HOSTNAME:-raspberrypi}
 
 export FIRST_USER_NAME=${FIRST_USER_NAME:-pi}
 export FIRST_USER_PASS
+export FORCE_USER_CREATION
 export RELEASE=${RELEASE:-bullseye}
 export WPA_ESSID
 export WPA_PASSWORD

--- a/build.sh
+++ b/build.sh
@@ -225,7 +225,7 @@ export TARGET_HOSTNAME=${TARGET_HOSTNAME:-raspberrypi}
 
 export FIRST_USER_NAME=${FIRST_USER_NAME:-pi}
 export FIRST_USER_PASS
-export FORCE_USER_CREATION
+export DISABLE_FIRST_BOOT_USER_RENAME=${DISABLE_FIRST_BOOT_USER_RENAME:-0}
 export RELEASE=${RELEASE:-bullseye}
 export WPA_ESSID
 export WPA_PASSWORD
@@ -289,6 +289,17 @@ dependencies_check "${BASE_DIR}/depends"
 if [[ ! "$FIRST_USER_NAME" =~ ^[a-z][-a-z0-9_]*$ ]]; then
 	echo "Invalid FIRST_USER_NAME: $FIRST_USER_NAME"
 	exit 1
+fi
+
+if [[ "$DISABLE_FIRST_BOOT_USER_RENAME" == "1" ]] && [ -z "${FIRST_USER_PASS}" ]; then
+	echo "To disable user rename on first boot, FIRST_USER_PASS needs to be set"
+	echo "Not setting FIRST_USER_PASS makes your system vulnerable and open to cyberattacks"
+	exit 1
+fi
+
+if [[ "$DISABLE_FIRST_BOOT_USER_RENAME" == "1" ]]; then
+	echo "User rename on the first boot is disabled"
+	echo "Be advised of the security risks linked to shipping a device with default username/password set."
 fi
 
 if [[ -n "${APT_PROXY}" ]] && ! curl --silent "${APT_PROXY}" >/dev/null ; then

--- a/export-image/01-user-rename/01-run.sh
+++ b/export-image/01-user-rename/01-run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
-on_chroot << EOF
-	SUDO_USER="${FIRST_USER_NAME}" rename-user -f -s
+if [ -z "${FORCE_USER_CREATION}" ]; then
+	on_chroot << EOF
+		SUDO_USER="${FIRST_USER_NAME}" rename-user -f -s
 EOF
+fi

--- a/export-image/01-user-rename/01-run.sh
+++ b/export-image/01-user-rename/01-run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 if [[ "${DISABLE_FIRST_BOOT_USER_RENAME}" == "0" ]]; then
-	on_chroot << EOF
+	on_chroot <<- EOF
 		SUDO_USER="${FIRST_USER_NAME}" rename-user -f -s
-EOF
+	EOF
 fi

--- a/export-image/01-user-rename/01-run.sh
+++ b/export-image/01-user-rename/01-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-if [ -z "${FORCE_USER_CREATION}" ]; then
+if [[ "${DISABLE_FIRST_BOOT_USER_RENAME}" == "0" ]]; then
 	on_chroot << EOF
 		SUDO_USER="${FIRST_USER_NAME}" rename-user -f -s
 EOF


### PR DESCRIPTION
This deactivates the export-image/01-user-rename/01-run.sh script when the `DISABLE_FIRST_BOOT_USER_RENAME` flag is set to `1`.
Closes #614.