### PR TITLE
Fix do not try to count mounts /proc /dev etc.

### DIFF
--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -11,7 +11,7 @@ if [ "${NO_PRERUN_QCOW2}" = "0" ]; then
 	mkdir -p "${ROOTFS_DIR}"
 
 	BOOT_SIZE="$((256 * 1024 * 1024))"
-	ROOT_SIZE=$(du --apparent-size -s "${EXPORT_ROOTFS_DIR}" --exclude var/cache/apt/archives --exclude boot --block-size=1 | cut -f 1)
+	ROOT_SIZE=$(du --one-file-system --apparent-size -s "${EXPORT_ROOTFS_DIR}" --exclude var/cache/apt/archives --exclude boot --block-size=1 | cut -f 1)
 
 	# All partition sizes and starts will be aligned to this size
 	ALIGN="$((4 * 1024 * 1024))"


### PR DESCRIPTION
On a busy server /proc may be to dynamic and du leads to errors like: 
du: cannot access work/stage2/rootfs/proc/4099/task/4912/fd/422'“: No such file or directory
That may lead to wrong size that is too big for truncate later on.