### PR TITLE
Update README.md document WPA_COUNTRY Code format

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The following environment variables are supported:
  * `WPA_ESSID`, `WPA_PASSWORD` and `WPA_COUNTRY` (Default: unset)
 
    If these are set, they are use to configure `wpa_supplicant.conf`, so that the Raspberry Pi can automatically connect to a wireless network on first boot. If `WPA_ESSID` is set and `WPA_PASSWORD` is unset an unprotected wireless network will be configured. If set, `WPA_PASSWORD` must be between 8 and 63 characters.
+    `WPA_COUNTRY` is a 2-letter ISO/IEC 3166 country Code, i.e. `GB`
 
  * `ENABLE_SSH` (Default: `0`)
 


### PR DESCRIPTION
It took me half a day to figure out why the image-building process stopped.

```
  if ! grep -q "^${REGDOMAIN}[[:space:]]" /usr/share/zoneinfo/iso3166.tab; then
    if [ "$INTERACTIVE" = True ]; then
      whiptail --msgbox "$REGDOMAIN is not a valid ISO/IEC 3166-1 alpha2 code" 20 60
    fi
    return 1
  fi
```

raspi-config will silently fail, if the argument to `do_wifi_country` is not an uppercase 2-letter Code from the list in `/usr/share/zoneinfo/iso3166.tab`

Document this in the readme.