### PR TITLE
apt/retries: specify option from the Acquire group

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ EOF
 			PACKAGES="$(sed -f "${SCRIPT_DIR}/remove-comments.sed" < "${i}-packages-nr")"
 			if [ -n "$PACKAGES" ]; then
 				on_chroot << EOF
-apt-get -o APT::Acquire::Retries=3 install --no-install-recommends -y $PACKAGES
+apt-get -o Acquire::Retries=3 install --no-install-recommends -y $PACKAGES
 EOF
 				if [ "${USE_QCOW2}" = "1" ]; then
 					on_chroot << EOF
@@ -36,7 +36,7 @@ EOF
 			PACKAGES="$(sed -f "${SCRIPT_DIR}/remove-comments.sed" < "${i}-packages")"
 			if [ -n "$PACKAGES" ]; then
 				on_chroot << EOF
-apt-get -o APT::Acquire::Retries=3 install -y $PACKAGES
+apt-get -o Acquire::Retries=3 install -y $PACKAGES
 EOF
 				if [ "${USE_QCOW2}" = "1" ]; then
 					on_chroot << EOF


### PR DESCRIPTION
retries did not work for me.

Per man apt.conf, Acquire group is not part of the apt group.

See also the [code](https://salsa.debian.org/apt-team/apt/-/commit/10631550f1f9788bdfd64d2434237a1448ab0626),
which looks for the config option `Retries(_config->FindI("Acquire::Retries",`  and **not `APT::Acquire::Retries`**

The only settings lookup I found was ever for `APT::Acquire::Translation`, which is deprecated.
```
apt (0.8.15) unstable; urgency=low
    - don't set deprecated APT::Acquire::Translation, thanks Jörg Sommer!
```

[ retries=3 later became standard, but wise to specify for all older versions ]