### PR TITLE
Ensure deploy is owned by user

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -121,8 +121,9 @@ else
 	wait "$!"
 fi
 
+# Ensure that deploy/ is always owned by calling user
 echo "copying results from deploy/"
-${DOCKER} cp "${CONTAINER_NAME}":/pi-gen/deploy .
+${DOCKER} cp "${CONTAINER_NAME}":/pi-gen/deploy - | tar -xf -
 ls -lah deploy
 
 # cleanup


### PR DESCRIPTION
Files copied out by `sudo docker cp ...` are owned by `root` and not the calling user.

Update the `build-docker.sh` to use tar streaming mode instead. As the receiving `tar` command is executed outside Docker the resulting directories & files are owned by the calling user. Hence you no longer need to use `sudo rm -rf deploy` to remove it.