### PR TITLE
Remove binfmt misc deps from Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
         git vim parted \
-        quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools \
-        libarchive-tools libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc\
-        binfmt-support ca-certificates qemu-utils kpartx fdisk gpg pigz\
+        quilt coreutils debootstrap zerofree zip dosfstools \
+        libarchive-tools libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc \
+        ca-certificates qemu-utils kpartx fdisk gpg pigz \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /pi-gen/

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -112,11 +112,11 @@ time ${DOCKER} run \
   -v /lib/modules:/lib/modules \
   ${PIGEN_DOCKER_OPTS} \
   --volume "${CONFIG_FILE}":/config:ro \
+  -e PIGEN_RUNNING_INSIDE_DOCKER=1 \
   -e "GIT_HASH=${GIT_HASH}" \
   "${DOCKER_CMDLINE_POST[@]}" \
   pi-gen \
   bash -e -o pipefail -c "
-    dpkg-reconfigure qemu-user-static &&
     # binfmt_misc is sometimes not mounted with debian bullseye image
     (mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc || true) &&
     cd /pi-gen; ./build.sh ${BUILD_OPTS} &&

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -87,39 +87,42 @@ esac
 ${DOCKER} build --build-arg BASE_IMAGE=${BASE_IMAGE} -t pi-gen "${DIR}"
 
 if [ "${CONTAINER_EXISTS}" != "" ]; then
-	trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${CONTAINER_NAME}_cont' SIGINT SIGTERM
-	time ${DOCKER} run --rm --privileged \
-		--cap-add=ALL \
-		-v /dev:/dev \
-		-v /lib/modules:/lib/modules \
-		${PIGEN_DOCKER_OPTS} \
-		--volume "${CONFIG_FILE}":/config:ro \
-		-e "GIT_HASH=${GIT_HASH}" \
-		--volumes-from="${CONTAINER_NAME}" --name "${CONTAINER_NAME}_cont" \
-		pi-gen \
-		bash -e -o pipefail -c "dpkg-reconfigure qemu-user-static &&
-	# binfmt_misc is sometimes not mounted with debian bullseye image
-	(mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc || true) &&
-	cd /pi-gen; ./build.sh ${BUILD_OPTS} &&
-	rsync -av work/*/build.log deploy/" &
-	wait "$!"
+  DOCKER_CMDLINE_NAME="${CONTAINER_NAME}_cont"
+  DOCKER_CMDLINE_PRE=( \
+    --rm \
+  )
+  DOCKER_CMDLINE_POST=( \
+    --volumes-from="${CONTAINER_NAME}" \
+  )
 else
-	trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${CONTAINER_NAME}' SIGINT SIGTERM
-	time ${DOCKER} run --name "${CONTAINER_NAME}" --privileged \
-		--cap-add=ALL \
-		-v /dev:/dev \
-		-v /lib/modules:/lib/modules \
-		${PIGEN_DOCKER_OPTS} \
-		--volume "${CONFIG_FILE}":/config:ro \
-		-e "GIT_HASH=${GIT_HASH}" \
-		pi-gen \
-		bash -e -o pipefail -c "dpkg-reconfigure qemu-user-static &&
-	# binfmt_misc is sometimes not mounted with debian bullseye image
-	(mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc || true) &&
-	cd /pi-gen; ./build.sh ${BUILD_OPTS} &&
-	rsync -av work/*/build.log deploy/" &
-	wait "$!"
+  DOCKER_CMDLINE_NAME="${CONTAINER_NAME}"
+  DOCKER_CMDLINE_PRE=( \
+  )
+  DOCKER_CMDLINE_POST=( \
+  )
 fi
+
+trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${DOCKER_CMDLINE_NAME}' SIGINT SIGTERM
+time ${DOCKER} run \
+  "${DOCKER_CMDLINE_PRE[@]}" \
+  --name "${DOCKER_CMDLINE_NAME}" \
+  --privileged \
+  --cap-add=ALL \
+  -v /dev:/dev \
+  -v /lib/modules:/lib/modules \
+  ${PIGEN_DOCKER_OPTS} \
+  --volume "${CONFIG_FILE}":/config:ro \
+  -e "GIT_HASH=${GIT_HASH}" \
+  "${DOCKER_CMDLINE_POST[@]}" \
+  pi-gen \
+  bash -e -o pipefail -c "
+    dpkg-reconfigure qemu-user-static &&
+    # binfmt_misc is sometimes not mounted with debian bullseye image
+    (mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc || true) &&
+    cd /pi-gen; ./build.sh ${BUILD_OPTS} &&
+    rsync -av work/*/build.log deploy/
+  " &
+  wait "$!"
 
 echo "copying results from deploy/"
 ${DOCKER} cp "${CONTAINER_NAME}":/pi-gen/deploy .

--- a/build.sh
+++ b/build.sh
@@ -288,6 +288,9 @@ if [ "$SETFCAP" != "1" ]; then
 fi
 
 dependencies_check "${BASE_DIR}/depends"
+if [ "${PIGEN_RUNNING_INSIDE_DOCKER}" != "1" ]; then
+  dependencies_check "${BASE_DIR}/depends.no-docker"
+fi
 
 #check username is valid
 if [[ ! "$FIRST_USER_NAME" =~ ^[a-z][-a-z0-9_]*$ ]]; then

--- a/depends
+++ b/depends
@@ -1,7 +1,6 @@
 quilt
 parted
 realpath:coreutils
-qemu-arm-static:qemu-user-static
 debootstrap
 zerofree
 zip

--- a/depends.no-docker
+++ b/depends.no-docker
@@ -1,0 +1,1 @@
+qemu-arm-static:qemu-user-static

--- a/export-image/00-allow-rerun/00-run.sh
+++ b/export-image/00-allow-rerun/00-run.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -e
 
-if [ ! -x "${ROOTFS_DIR}/usr/bin/qemu-arm-static" ]; then
-	cp /usr/bin/qemu-arm-static "${ROOTFS_DIR}/usr/bin/"
+if [ "${PIGEN_RUNNING_INSIDE_DOCKER}" != "1" ]; then
+  if [ ! -x "${ROOTFS_DIR}/usr/bin/qemu-arm-static" ]; then
+    cp /usr/bin/qemu-arm-static "${ROOTFS_DIR}/usr/bin/"
+  fi
 fi
 
 if [ -e "${ROOTFS_DIR}/etc/ld.so.preload" ]; then


### PR DESCRIPTION
In Docker build `binfmt_misc` support is provided by the host, hence we do not need to install any of its dependencies inside the image.

DRY removal: now there is only on `docker run` command line to maintain in the script.