### PR TITLE
Update qemu ARM binary name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ To resolve this, ensure that the following files are available (install them if 
 
 ```
 /lib/modules/$(uname -r)/kernel/fs/binfmt_misc.ko
-/usr/bin/qemu-arm-static
+/usr/bin/qemu-aarch64-static
 ```
 
 You may also need to load the module by hand - run `modprobe binfmt_misc`.


### PR DESCRIPTION
When running a 64 bit build you need the QEMU aarch64 binary installed on the host system.

Fixes #678