### PR TITLE
Register binfmt_misc entry for docker build

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -107,6 +107,40 @@ else
   )
 fi
 
+# Check if binfmt_misc is required
+binfmt_misc_required=1
+case $(uname -m) in
+  aarch64)
+    binfmt_misc_required=0
+    ;;
+  arm*)
+    binfmt_misc_required=0
+    ;;
+esac
+
+# Check if qemu-arm-static and /proc/sys/fs/binfmt_misc are present
+if [[ "${binfmt_misc_required}" == "1" ]]; then
+  if ! qemu_arm=$(which qemu-arm-static) ; then
+    echo "qemu-arm-static not found (please install qemu-user-static)"
+    exit 1
+  fi
+  if [ ! -f /proc/sys/fs/binfmt_misc/register ]; then
+    echo "binfmt_misc required but not mounted, trying to mount it..."
+    if ! mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc ; then
+        echo "mounting binfmt_misc failed"
+        exit 1
+    fi
+    echo "binfmt_misc mounted"
+  fi
+  # Register qemu-arm for binfmt_misc (binfmt_misc won't care duplicate entries unless they have common names)
+  reg="echo ':qemu-arm-rpi:M::"\
+"\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:"\
+"\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:"\
+"$qemu_arm:F' > /proc/sys/fs/binfmt_misc/register"
+  echo "Registering qemu-arm for binfmt_misc..."
+  sudo bash -c "$reg" 2>/dev/null || true
+fi
+
 trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${DOCKER_CMDLINE_NAME}' SIGINT SIGTERM
 time ${DOCKER} run \
   "${DOCKER_CMDLINE_PRE[@]}" \


### PR DESCRIPTION
In some distros (like some archlinux based distros) qemu-user-static package doesn't register qemu for binfmt and causes problem. [multiarch/qemu-user-static](https://github.com/multiarch/qemu-user-static) solves this by a simple privileged docker run. AFAIK it doesn't make any conflict with existing qemu-user-static packages and it's a universal solution. I think it's good to use this in the docker build script in order to prevent possible problems on various distros.