### PR TITLE
Copy container log to deploy

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -132,6 +132,10 @@ time ${DOCKER} run \
 # Ensure that deploy/ is always owned by calling user
 echo "copying results from deploy/"
 ${DOCKER} cp "${CONTAINER_NAME}":/pi-gen/deploy - | tar -xf -
+
+echo "copying log from container ${CONTAINER_NAME} to depoy/"
+${DOCKER} logs --timestamps "${CONTAINER_NAME}" &>deploy/build-docker.log
+
 ls -lah deploy
 
 # cleanup


### PR DESCRIPTION
The container log is much more detailed than the default build.log, which makes life much easier for a build maintainer. Before deleting the container copy the log out to the deploy/ directory.