### PR TITLE
Register aarch64 in binfmt misc

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -132,13 +132,15 @@ if [[ "${binfmt_misc_required}" == "1" ]]; then
     fi
     echo "binfmt_misc mounted"
   fi
-  # Register qemu-arm for binfmt_misc (binfmt_misc won't care duplicate entries unless they have common names)
-  reg="echo ':qemu-arm-rpi:M::"\
+  if ! grep -q "^interpreter ${qemu_arm}" /proc/sys/fs/binfmt_misc/qemu-arm* ; then
+    # Register qemu-arm for binfmt_misc
+    reg="echo ':qemu-arm-rpi:M::"\
 "\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:"\
 "\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:"\
-"$qemu_arm:F' > /proc/sys/fs/binfmt_misc/register"
-  echo "Registering qemu-arm for binfmt_misc..."
-  sudo bash -c "$reg" 2>/dev/null || true
+"${qemu_arm}:F' > /proc/sys/fs/binfmt_misc/register"
+    echo "Registering qemu-arm for binfmt_misc..."
+    sudo bash -c "${reg}" 2>/dev/null || true
+  fi
 fi
 
 trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${DOCKER_CMDLINE_NAME}' SIGINT SIGTERM

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -118,10 +118,10 @@ case $(uname -m) in
     ;;
 esac
 
-# Check if qemu-arm-static and /proc/sys/fs/binfmt_misc are present
+# Check if qemu-aarch64-static and /proc/sys/fs/binfmt_misc are present
 if [[ "${binfmt_misc_required}" == "1" ]]; then
-  if ! qemu_arm=$(which qemu-arm-static) ; then
-    echo "qemu-arm-static not found (please install qemu-user-static)"
+  if ! qemu_arm=$(which qemu-aarch64-static) ; then
+    echo "qemu-aarch64-static not found (please install qemu-user-static)"
     exit 1
   fi
   if [ ! -f /proc/sys/fs/binfmt_misc/register ]; then
@@ -132,13 +132,13 @@ if [[ "${binfmt_misc_required}" == "1" ]]; then
     fi
     echo "binfmt_misc mounted"
   fi
-  if ! grep -q "^interpreter ${qemu_arm}" /proc/sys/fs/binfmt_misc/qemu-arm* ; then
-    # Register qemu-arm for binfmt_misc
-    reg="echo ':qemu-arm-rpi:M::"\
-"\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:"\
+  if ! grep -q "^interpreter ${qemu_arm}" /proc/sys/fs/binfmt_misc/qemu-aarch64* ; then
+    # Register qemu-aarch64 for binfmt_misc
+    reg="echo ':qemu-aarch64-rpi:M::"\
+"\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00:"\
 "\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:"\
 "${qemu_arm}:F' > /proc/sys/fs/binfmt_misc/register"
-    echo "Registering qemu-arm for binfmt_misc..."
+    echo "Registering qemu-aarch64 for binfmt_misc..."
     sudo bash -c "${reg}" 2>/dev/null || true
   fi
 fi


### PR DESCRIPTION
This modifies commit 6dc45a80e764eacd6e311c32164b623bbe7f8e08 for the
arm64 branch. For 64-bit builds we need to register qemu-aarch64-static
instead.

Improves on #685