### PR TITLE
add backing image format as required by newer qemu

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -365,7 +365,7 @@ for EXPORT_DIR in ${EXPORT_DIRS}; do
 				continue
 			fi
 		echo "Rebasing image-${CURR_STAGE}.qcow2 onto ${PREV_IMG}.qcow2"
-			qemu-img rebase -f qcow2 -u -b ${PREV_IMG}.qcow2 image-${CURR_STAGE}.qcow2
+			qemu-img rebase -F qcow2 -f qcow2 -u -b ${PREV_IMG}.qcow2 image-${CURR_STAGE}.qcow2
 			if [ "${CURR_STAGE}" = "${EXPORT_STAGE}" ]; then
 				break
 			fi
@@ -383,7 +383,7 @@ for EXPORT_DIR in ${EXPORT_DIRS}; do
 				continue
 			fi
 		echo "Rebasing back image-${CURR_STAGE}.qcow2 onto ${PREV_IMG}.qcow2"
-			qemu-img rebase -f qcow2 -u -b ${PREV_IMG}.qcow2 image-${CURR_STAGE}.qcow2
+			qemu-img rebase -F qcow2 -f qcow2 -u -b ${PREV_IMG}.qcow2 image-${CURR_STAGE}.qcow2
 			if [ "${CURR_STAGE}" = "${EXPORT_STAGE}" ]; then
 				break
 			fi

--- a/scripts/qcow2_handling
+++ b/scripts/qcow2_handling
@@ -117,7 +117,7 @@ EOF
 					exit 1;
 				fi
 				echo "Creating backing image: image-${STAGE}.qcow2 <- ${WORK_DIR}/image-${PREV_STAGE}.qcow2"
-				qemu-img create -f qcow2 \
+				qemu-img create -F qcow2 -f qcow2 \
 					-o backing_file=${WORK_DIR}/image-${PREV_STAGE}.qcow2 \
 					${WORK_DIR}/image-${STAGE}.qcow2
 				sync


### PR DESCRIPTION
qemu-img requires specifying the backing image format (since [6.1](https://wiki.qemu.org/ChangeLog/6.1))