### PR TITLE
fix: support bash v3 by removing array usage

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+# Note: Avoid usage of arrays as MacOS users have an older version of bash (v3.x) which does not supports arrays
+set -eu
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -84,18 +86,12 @@ ${DOCKER} build --build-arg BASE_IMAGE=debian:bullseye -t pi-gen "${DIR}"
 
 if [ "${CONTAINER_EXISTS}" != "" ]; then
   DOCKER_CMDLINE_NAME="${CONTAINER_NAME}_cont"
-  DOCKER_CMDLINE_PRE=( \
-    --rm \
-  )
-  DOCKER_CMDLINE_POST=( \
-    --volumes-from="${CONTAINER_NAME}" \
-  )
+  DOCKER_CMDLINE_PRE="--rm"
+  DOCKER_CMDLINE_POST="--volumes-from=\"${CONTAINER_NAME}\""
 else
   DOCKER_CMDLINE_NAME="${CONTAINER_NAME}"
-  DOCKER_CMDLINE_PRE=( \
-  )
-  DOCKER_CMDLINE_POST=( \
-  )
+  DOCKER_CMDLINE_PRE=""
+  DOCKER_CMDLINE_POST=""
 fi
 
 # Check if binfmt_misc is required
@@ -136,7 +132,7 @@ fi
 
 trap 'echo "got CTRL+C... please wait 5s" && ${DOCKER} stop -t 5 ${DOCKER_CMDLINE_NAME}' SIGINT SIGTERM
 time ${DOCKER} run \
-  "${DOCKER_CMDLINE_PRE[@]}" \
+  $DOCKER_CMDLINE_PRE \
   --name "${DOCKER_CMDLINE_NAME}" \
   --privileged \
   --cap-add=ALL \
@@ -145,7 +141,7 @@ time ${DOCKER} run \
   ${PIGEN_DOCKER_OPTS} \
   --volume "${CONFIG_FILE}":/config:ro \
   -e "GIT_HASH=${GIT_HASH}" \
-  "${DOCKER_CMDLINE_POST[@]}" \
+  $DOCKER_CMDLINE_POST \
   pi-gen \
   bash -e -o pipefail -c "
     dpkg-reconfigure qemu-user-static &&

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -2,7 +2,7 @@
 # Note: Avoid usage of arrays as MacOS users have an older version of bash (v3.x) which does not supports arrays
 set -eu
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 
 BUILD_OPTS="$*"
 


### PR DESCRIPTION
Improve compatibility of the `docker-compose.yaml` script by supporting bash v3. MacOS users only have bash v3 by default (due to licensing).