### PR TITLE
stage0: remove unnecessary firmware packages

### DIFF
--- a/stage0/02-firmware/01-packages-nr
+++ b/stage0/02-firmware/01-packages-nr
@@ -1,9 +1,9 @@
 initramfs-tools
+zstd
 raspi-firmware
+firmware-linux-free
+bluez-firmware
 linux-image-rpi-v6
 linux-image-rpi-v7
 linux-image-rpi-v7l
 linux-image-rpi-v8
-linux-headers-rpi-v6
-linux-headers-rpi-v7
-linux-headers-rpi-v7l


### PR DESCRIPTION
While merging the Debian Bookworm changes into our tailored stage2 baseline branch I noticed that about 50 additional packages were installed compared to Bullseye, e.g. full gcc, man pages and *-dev packages. None of them are required to build or run the stage2 image.

For the default Raspi OS stage2 build, i.e. -lite image, this change doesn't have any big effects, because the above mentioned packages are dragged in via dependencies for other packages. We gave removed these packages in our tailored configuration.

The changes to step `02-firmware`:

- move `01-packages` to `01-packages-nr`
- remove `linux-headers-*`
- add `zstd` & firmware packages from recommends list that aren't listed in another step.

**NOTE:** this will cause merge conflicts with `arm64` branch. Similar changes need to be done for the arm64 configuration.

