### PR TITLE
README.md: add PI_GEN_RELEASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ The following environment variables are supported:
    but you should use something else for a customized version.  Export files
    in stages may add suffixes to `IMG_NAME`.
 
+ * `PI_GEN_RELEASE` (Default: `Raspberry Pi reference`)
+
+   The release name to use in `/etc/issue.txt`. The default should only be used
+   for official Raspberry Pi builds.
+
 * `USE_QCOW2` **EXPERIMENTAL** (Default: `0` )
 
     Instead of using traditional way of building the rootfs of every stage in

--- a/build.sh
+++ b/build.sh
@@ -194,6 +194,7 @@ trap term EXIT INT TERM
 
 export PI_GEN=${PI_GEN:-pi-gen}
 export PI_GEN_REPO=${PI_GEN_REPO:-https://github.com/RPi-Distro/pi-gen}
+export PI_GEN_RELEASE=${PI_GEN_RELEASE:-Raspberry Pi reference}
 
 if [ -z "${IMG_NAME}" ]; then
 	echo "IMG_NAME not set" 1>&2

--- a/scripts/common
+++ b/scripts/common
@@ -99,7 +99,7 @@ on_chroot() {
 export -f on_chroot
 
 update_issue() {
-	echo -e "Raspberry Pi reference ${IMG_DATE}\nGenerated using ${PI_GEN}, ${PI_GEN_REPO}, ${GIT_HASH}, ${1}" > "${ROOTFS_DIR}/etc/rpi-issue"
+	echo -e "${PI_GEN_RELEASE} ${IMG_DATE}\nGenerated using ${PI_GEN}, ${PI_GEN_REPO}, ${GIT_HASH}, ${1}" > "${ROOTFS_DIR}/etc/rpi-issue"
 }
 export -f update_issue
 


### PR DESCRIPTION
This is the text written to "/etc/issue.txt" by update_issue(). The default is the name used by official Raspberry Pi builds.

Fixes #719