### PR TITLE
Enable mouse_snap in Wayfire

### DIFF
--- a/stage4/08-configure-wayfire/00-run.sh
+++ b/stage4/08-configure-wayfire/00-run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+sed -i 's/^mouse_snap = .*$/mouse_snap = true/' "${ROOTFS_DIR}/etc/wayfire/defaults.ini"


### PR DESCRIPTION
This PR enables snapping windows then moved to screen borders. This is a feature users have come to expect from other operating systems and desktop environments.

Reference:
* https://github.com/WayfireWM/wayfire/discussions/2018