### PR TITLE
Ensure loop device partition nodes are created

### DIFF
--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -46,6 +46,7 @@ if [ "${NO_PRERUN_QCOW2}" = "0" ]; then
 		fi
 	done
 
+	ensure_loopdev_partitions "$LOOP_DEV"
 	BOOT_DEV="${LOOP_DEV}p1"
 	ROOT_DEV="${LOOP_DEV}p2"
 

--- a/export-noobs/prerun.sh
+++ b/export-noobs/prerun.sh
@@ -22,6 +22,7 @@ until ensure_next_loopdev && LOOP_DEV="$(losetup --show --find --partscan "$IMG_
 	fi
 done
 
+ensure_loopdev_partitions "$LOOP_DEV"
 BOOT_DEV="${LOOP_DEV}p1"
 ROOT_DEV="${LOOP_DEV}p2"
 

--- a/scripts/common
+++ b/scripts/common
@@ -110,3 +110,17 @@ ensure_next_loopdev() {
 	[[ -b "$loopdev" ]] || mknod "$loopdev" b 7 "$loopmaj"
 }
 export -f ensure_next_loopdev
+
+ensure_loopdev_partitions() {
+	local line
+	local partition
+	local majmin
+	lsblk -r -n -o "NAME,MAJ:MIN" "$1" | grep -v "^${1#/dev/} " | while read -r line; do
+		partition="${line%% *}"
+		majmin="${line#* }"
+		if [ ! -b "/dev/$partition" ]; then
+			mknod "/dev/$partition" b "${majmin%:*}" "${majmin#*:}"
+		fi
+	done
+}
+export -f ensure_loopdev_partitions


### PR DESCRIPTION
Although the loop block device is created before attaching the image to it, the devices for the partition that the image contains are still not created. This patch creates those devices as well, when they are not already available.

Fixes #482