### PR TITLE
FIX: Install ca-certificates during bootstrap

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -16,6 +16,8 @@ bootstrap(){
 	BOOTSTRAP_ARGS+=(--arch armhf)
 	BOOTSTRAP_ARGS+=(--components "main,contrib,non-free")
 	BOOTSTRAP_ARGS+=(--keyring "${STAGE_DIR}/files/raspberrypi.gpg")
+	BOOTSTRAP_ARGS+=(--exclude=info)
+	BOOTSTRAP_ARGS+=(--include=ca-certificates)
 	BOOTSTRAP_ARGS+=("$@")
 	printf -v BOOTSTRAP_STR '%q ' "${BOOTSTRAP_ARGS[@]}"
 


### PR DESCRIPTION
Fixes #659
Same as #424
Can we fix this in the buster branch. I have cherry picked 40f67ce4bac65cb8f92a4a9ac72b05bc36ccedeb which is the fix in #424