### PR TITLE
Compare mount output using base of dirname

### DIFF
--- a/export-image/05-finalise/01-run.sh
+++ b/export-image/05-finalise/01-run.sh
@@ -83,7 +83,7 @@ cp "$ROOTFS_DIR/etc/rpi-issue" "$INFO_FILE"
 	dpkg -l --root "$ROOTFS_DIR"
 } >> "$INFO_FILE"
 
-ROOT_DEV="$(mount | grep " ${ROOTFS_DIR} " | cut -f1 -d' ')"
+ROOT_DEV="$(awk "\$2 == \"${ROOTFS_DIR}\" {print \$1}" /etc/mtab)"
 
 unmount "${ROOTFS_DIR}"
 zerofree "${ROOT_DEV}"

--- a/export-image/05-finalise/01-run.sh
+++ b/export-image/05-finalise/01-run.sh
@@ -83,7 +83,7 @@ cp "$ROOTFS_DIR/etc/rpi-issue" "$INFO_FILE"
 	dpkg -l --root "$ROOTFS_DIR"
 } >> "$INFO_FILE"
 
-ROOT_DEV="$(mount | grep "${ROOTFS_DIR} " | cut -f1 -d' ')"
+ROOT_DEV="$(mount | grep " ${ROOTFS_DIR} " | cut -f1 -d' ')"
 
 unmount "${ROOTFS_DIR}"
 zerofree "${ROOT_DEV}"

--- a/scripts/common
+++ b/scripts/common
@@ -44,12 +44,15 @@ unmount(){
 		DIR=$1
 	fi
 
-	while mount | grep -q "$DIR"; do
-		local LOCS
-		LOCS=$(mount | grep " $DIR" | cut -f 3 -d ' ' | sort -r)
-		for loc in $LOCS; do
-			umount "$loc"
-		done
+	for i in {1..6}; do
+		if awk "\$2 ~ /^${DIR//\//\\/}/ {print \$2}" /etc/mtab | sort -r | xargs -r umount; then
+			break
+		elif [ "$i" -eq 6 ]; then
+			log "Failed to unmount ${DIR}. Do not try to delete this directory while it contains mountpoints!"
+			return 1
+		fi
+		log "Retrying ($i/5)..."
+		sleep 1
 	done
 }
 export -f unmount

--- a/scripts/common
+++ b/scripts/common
@@ -46,7 +46,7 @@ unmount(){
 
 	while mount | grep -q "$DIR"; do
 		local LOCS
-		LOCS=$(mount | grep "$DIR" | cut -f 3 -d ' ' | sort -r)
+		LOCS=$(mount | grep " $DIR" | cut -f 3 -d ' ' | sort -r)
 		for loc in $LOCS; do
 			umount "$loc"
 		done


### PR DESCRIPTION
If you're building from a bind-mounted directory, the build will fail as it will find two entries to unmount, but a single unmount will remove them both causing an error. Adding a space means that the mountpoint will only match with a single mount entry ; the expected path, rather than the pre bind-mount.

Fixes issue #770 