### PR TITLE
Adds GitHub Action to Build Raspbian Lite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Build Image
       run: |
-        ls
+        chmod a+x build-docker.sh 
         ./build-docker.sh
 
     - name: Get Image Name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Maximize Build Space
       uses: easimon/maximize-build-space@master
       with:
-        root-reserve-mb: 25000 
+        root-reserve-mb: 20000 
         swap-size-mb: 1024
         remove-dotnet: 'true'
         remove-android: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Maximize Build Space
       uses: easimon/maximize-build-space@master
       with:
-        root-reserve-mb: 10240
+        root-reserve-mb: 4096 
         swap-size-mb: 1024
         remove-dotnet: 'true'
         remove-android: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
     - name: Create Config File
       id: config
       run: |
+        touch config
         NOW=$(date +"%Y-%m-%d-%H%M")
         IMAGE=Raspbian-${GITHUB_REF##*/}-$NOW
         echo "image=$IMAGE"                        >> $GITHUB_OUTPUT
@@ -52,7 +53,6 @@ jobs:
 
     - name: Build Image
       run: |
-        chmod a+x build-docker.sh 
         ./build-docker.sh
 
     - name: Get Image Name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,6 @@ jobs:
 
     - name: Build Image
       run: |
-        cd PiGen
         ./build-docker.sh
 
     - name: Get Image Name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,7 @@
 name: Build Image
 
-on:
-  repository_dispatch:
-  workflow_dispatch:
-  push:
-  schedule: 
-    - cron: '0 0 1 * *'
+on: [push]
 
-# TODO:  These jobs are so similar except for just ssh.
-#        I'd love to find a way to not have so much repetition between these configurations.
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,7 +25,11 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt install -y coreutils quilt parted qemu-user-static debootstrap zerofree zip dosfstools libarchive-tools libcap2-bin grep rsync xz-utils file git curl bc qemu-utils kpartx gpg
+        sudo apt install -y coreutils quilt parted qemu-user-static \
+                            debootstrap zerofree zip dosfstools     \
+                            libarchive-tools libcap2-bin grep rsync \
+                            xz-utils file git curl bc qemu-utils    \
+                            kpartx gpg
 
     - name: Checkout PiGen
       uses: actions/checkout@v3
@@ -66,7 +63,8 @@ jobs:
         IMAGE_FILE=$(ls *.zip)
         echo "imagefile=$IMAGE_FILE" >> $GITHUB_OUTPUT
 
-    # The image now exists in deploy/.  Let's save it somewhere.
+    # The image now exists in deploy/. 
+    # Make the artifact available from the action.
     - uses: actions/upload-artifact@v1
       with:
         name: ${{ steps.config.outputs.image }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,13 @@ jobs:
     - name: Maximize Build Space
       uses: easimon/maximize-build-space@master
       with:
-        root-reserve-mb: 10240 
+#        root-reserve-mb: 10240
         swap-size-mb: 1024
         remove-dotnet: 'true'
         remove-android: 'true'
         remove-haskell: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
 
     - name: List Available Space
       run: |
@@ -44,12 +46,13 @@ jobs:
         echo IMG_NAME=$IMAGE >> config
         echo "image=$IMAGE"  >> $GITHUB_OUTPUT
 
-    # Greatly speed up our build because we don't need a desktop
-    # or anything more advanced for our little IoT devices.
+    # At this time the GitHub runners don't have enough
+    # space to support building normal Raspberry Pi OS (Stage 4)
+    # or Full Raspberry Pi OS (Stage 5) builds.
+    # Uncomment this to build them in a future where they do!
 #    - name: Disable Non-Lite Builds
 #      run: |
-#        cd PiGen
-#        touch ./stage3/SKIP ./stage4/SKIP ./stage5/SKIP
+#        touch ./stage4/SKIP ./stage5/SKIP
 #        touch ./stage4/SKIP_IMAGES ./stage5/SKIP_IMAGES
 
     - name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Maximize Build Space
       uses: easimon/maximize-build-space@master
       with:
-#        root-reserve-mb: 10240
+        root-reserve-mb: 10240
         swap-size-mb: 1024
         remove-dotnet: 'true'
         remove-android: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,10 @@ jobs:
 
     - name: Checkout PiGen
       uses: actions/checkout@v3
-      with:
-        path: PiGen
 
     - name: Create Config File
       id: config
       run: |
-        cd PiGen
         NOW=$(date +"%Y-%m-%d-%H%M")
         IMAGE=Raspbian-${GITHUB_REF##*/}-$NOW
         echo "image=$IMAGE"                        >> $GITHUB_OUTPUT
@@ -60,7 +57,6 @@ jobs:
     - name: Get Image Name
       id: imagefile
       run: |
-        cd PiGen
         cd deploy
         ls
         IMAGE_FILE=$(ls *.img)
@@ -70,4 +66,4 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: ${{ steps.config.outputs.image }}
-        path: PiGen/deploy/${{ steps.imagefile.outputs.imagefile }}
+        path: deploy/${{ steps.imagefile.outputs.imagefile }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,74 @@
+name: Build Image
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  push:
+  schedule: 
+    - cron: '0 0 1 * *'
+
+# TODO:  These jobs are so similar except for just ssh.
+#        I'd love to find a way to not have so much repetition between these configurations.
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Maximize Build Space
+      uses: easimon/maximize-build-space@master
+      with:
+        root-reserve-mb: 10240 
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+
+    - name: List Available Space
+      run: |
+        echo "Free space:"
+        df -h
+
+    - name: Install Dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y coreutils quilt parted qemu-user-static debootstrap zerofree zip dosfstools libarchive-tools libcap2-bin grep rsync xz-utils file git curl bc qemu-utils kpartx gpg
+
+    - name: Checkout PiGen
+      uses: actions/checkout@v3
+      with:
+        path: PiGen
+
+    - name: Create Config File
+      id: config
+      run: |
+        cd PiGen
+        NOW=$(date +"%Y-%m-%d-%H%M")
+        IMAGE=Raspbian-${GITHUB_REF##*/}-$NOW
+        echo "image=$IMAGE"                        >> $GITHUB_OUTPUT
+
+    # Greatly speed up our build because we don't need a desktop
+    # or anything more advanced for our little IoT devices.
+#    - name: Disable Non-Lite Builds
+#      run: |
+#        cd PiGen
+#        touch ./stage3/SKIP ./stage4/SKIP ./stage5/SKIP
+#        touch ./stage4/SKIP_IMAGES ./stage5/SKIP_IMAGES
+
+    - name: Build Image
+      run: |
+        cd PiGen
+        ./build-docker.sh
+
+    - name: Get Image Name
+      id: imagefile
+      run: |
+        cd PiGen
+        cd deploy
+        ls
+        IMAGE_FILE=$(ls *.img)
+        echo "imagefile=$IMAGE_FILE" >> $GITHUB_OUTPUT
+
+    # The image now exists in deploy/.  Let's save it somewhere.
+    - uses: actions/upload-artifact@v1
+      with:
+        name: ${{ steps.config.outputs.image }}
+        path: PiGen/deploy/${{ steps.imagefile.outputs.imagefile }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,10 @@ jobs:
     # space to support building normal Raspberry Pi OS (Stage 4)
     # or Full Raspberry Pi OS (Stage 5) builds.
     # Uncomment this to build them in a future where they do!
-   - name: Disable Full Build
-     run: |
-       touch ./stage5/SKIP
-       touch ./stage5/SKIP_IMAGES
+    - name: Disable Full Build
+      run: |
+        touch ./stage5/SKIP
+        touch ./stage5/SKIP_IMAGES
 
     - name: Build Image
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,13 +47,12 @@ jobs:
         echo "image=$IMAGE"  >> $GITHUB_OUTPUT
 
     # At this time the GitHub runners don't have enough
-    # space to support building normal Raspberry Pi OS (Stage 4)
-    # or Full Raspberry Pi OS (Stage 5) builds.
+    # space to support building non-Lite builds.
     # Remove this to build them in a future where they do!
-    - name: Disable Stage4 and Stage5 Builds
+    - name: Disable Non-Lite Builds
       run: |
-        touch ./stage5/SKIP ./stage4/SKIP
-        touch ./stage5/SKIP_IMAGES ./stage4/SKIP_IMAGES
+        touch ./stage5/SKIP ./stage4/SKIP ./stage3/SKIP
+        touch ./stage5/SKIP_IMAGES ./stage4/SKIP_IMAGES ./stage3/SKIP_IMAGES
 
     - name: Build Image
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         cd deploy
         ls
-        IMAGE_FILE=$(ls *.img)
+        IMAGE_FILE=$(ls *.zip)
         echo "imagefile=$IMAGE_FILE" >> $GITHUB_OUTPUT
 
     # The image now exists in deploy/.  Let's save it somewhere.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Maximize Build Space
       uses: easimon/maximize-build-space@master
       with:
-        root-reserve-mb: 15000 
+        root-reserve-mb: 25000 
         swap-size-mb: 1024
         remove-dotnet: 'true'
         remove-android: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,11 @@ jobs:
     - name: Create Config File
       id: config
       run: |
-        touch config
         NOW=$(date +"%Y-%m-%d-%H%M")
         IMAGE=Raspbian-${GITHUB_REF##*/}-$NOW
-        echo "image=$IMAGE"                        >> $GITHUB_OUTPUT
+        touch config
+        echo IMG_NAME=$IMAGE >> config
+        echo "image=$IMAGE"  >> $GITHUB_OUTPUT
 
     # Greatly speed up our build because we don't need a desktop
     # or anything more advanced for our little IoT devices.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Maximize Build Space
       uses: easimon/maximize-build-space@master
       with:
-        root-reserve-mb: 4096 
+        root-reserve-mb: 15000 
         swap-size-mb: 1024
         remove-dotnet: 'true'
         remove-android: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Maximize Build Space
       uses: easimon/maximize-build-space@master
       with:
-        root-reserve-mb: 20000 
+        root-reserve-mb: 10000 
         swap-size-mb: 1024
         remove-dotnet: 'true'
         remove-android: 'true'
@@ -49,11 +49,11 @@ jobs:
     # At this time the GitHub runners don't have enough
     # space to support building normal Raspberry Pi OS (Stage 4)
     # or Full Raspberry Pi OS (Stage 5) builds.
-    # Uncomment this to build them in a future where they do!
-    - name: Disable Full Build
+    # Remove this to build them in a future where they do!
+    - name: Disable Stage4 and Stage5 Builds
       run: |
-        touch ./stage5/SKIP
-        touch ./stage5/SKIP_IMAGES
+        touch ./stage5/SKIP ./stage4/SKIP
+        touch ./stage5/SKIP_IMAGES ./stage4/SKIP_IMAGES
 
     - name: Build Image
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,10 @@ jobs:
     # space to support building normal Raspberry Pi OS (Stage 4)
     # or Full Raspberry Pi OS (Stage 5) builds.
     # Uncomment this to build them in a future where they do!
-#    - name: Disable Non-Lite Builds
-#      run: |
-#        touch ./stage4/SKIP ./stage5/SKIP
-#        touch ./stage4/SKIP_IMAGES ./stage5/SKIP_IMAGES
+   - name: Disable Full Build
+     run: |
+       touch ./stage5/SKIP
+       touch ./stage5/SKIP_IMAGES
 
     - name: Build Image
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
 
     - name: Build Image
       run: |
+        ls
         ./build-docker.sh
 
     - name: Get Image Name


### PR DESCRIPTION
This action uses entirely default settings, and disables stage3-stage5 builds.  I was unable to get any of these builds to complete within the space constraints of the GitHub runners, but if they add disk space to their runners it may be possible to build these in the future.

Tested and confirmed working on a Raspberry Pi Zero W.

Completes #785 