### PR TITLE
Dockerfile: fix ENV warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=debian:bullseye
 FROM ${BASE_IMAGE}
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \


### PR DESCRIPTION
Newer versions of docker generate the following warning

   - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 4)