### PR TITLE
Allow export image customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ The following environment variables are supported:
 
     If set, then instead of working through the numeric stages in order, this list will be followed. For example setting to `"stage0 stage1 mystage stage2"` will run the contents of `mystage` before stage2. Note that quotes are needed around the list. An absolute or relative path can be given for stages outside the pi-gen directory.
 
+ * `EXPORT_CONFIG_DIR` (Default: `$BASE_DIR/export-image`)
+
+    If set, use this directory path as the location of scripts to run when generating images. An absolute or relative path can be given for a location outside the pi-gen directory.
+
 A simple example for building Raspberry Pi OS:
 
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -301,6 +301,10 @@ log "Begin ${BASE_DIR}"
 STAGE_LIST=${STAGE_LIST:-${BASE_DIR}/stage*}
 export STAGE_LIST
 
+EXPORT_CONFIG_DIR=$(realpath ${EXPORT_CONFIG_DIR:-"${BASE_DIR}/export-image"})
+if [ ! -d ${EXPORT_CONFIG_DIR} ]; then echo "EXPORT_CONFIG_DIR invalid" 1>&2; exit 1; fi
+export EXPORT_CONFIG_DIR
+
 for STAGE_DIR in $STAGE_LIST; do
 	STAGE_DIR=$(realpath "${STAGE_DIR}")
 	run_stage
@@ -308,7 +312,7 @@ done
 
 CLEAN=1
 for EXPORT_DIR in ${EXPORT_DIRS}; do
-	STAGE_DIR=${BASE_DIR}/export-image
+	STAGE_DIR=${EXPORT_CONFIG_DIR}
 	# shellcheck source=/dev/null
 	source "${EXPORT_DIR}/EXPORT_IMAGE"
 	EXPORT_ROOTFS_DIR=${WORK_DIR}/$(basename "${EXPORT_DIR}")/rootfs


### PR DESCRIPTION
Add new variable EXPORT_CONFIG_DIR to set the location of the scripts pigen will run when exporting an image. Setting this is optional. If not specified, the current location is retained.

By utilising STAGE_LIST AND EXPORT_CONFIG_DIR, a user can construct custom images out-of-tree without modification to any defaults.

(cherry picked from commit e5e6ceeaf46f52f77b759d3d35aef8bbd0a69c8b)