### PR TITLE
Use the depends file for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,10 @@ FROM ${BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update && \
-    apt-get -y install --no-install-recommends \
-        git vim parted \
-        quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools \
-        libarchive-tools libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc \
-        binfmt-support ca-certificates fdisk gpg pigz arch-test \
-    && rm -rf /var/lib/apt/lists/*
-
 COPY . /pi-gen/
+
+RUN apt-get -y update && \
+    apt-get install -y $(sed "s/.*://g" /pi-gen/depends) && \
+    && rm -rf /var/lib/apt/lists/*
 
 VOLUME [ "/pi-gen/work", "/pi-gen/deploy"]

--- a/depends
+++ b/depends
@@ -20,3 +20,7 @@ bc
 gpg
 pigz
 arch-test
+udev
+binfmt-support
+ca-certificates
+fdisk

--- a/depends
+++ b/depends
@@ -24,3 +24,4 @@ udev
 binfmt-support
 ca-certificates
 fdisk
+bmap-tools


### PR DESCRIPTION
For a project I'm running based on pi-gen we modified the Dockerfile in a number of project specific ways.
Additionally, we changed the dependency installation to use the `depends` file.

This makes dependency management easier, as only the `depends` file has to be maintained, instead of both the `Dockerfile` and the `depends` files.