### PR TITLE
Align partition start boundaries to 8M

### DIFF
--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -13,7 +13,7 @@ BOOT_SIZE="$((512 * 1024 * 1024))"
 ROOT_SIZE=$(du -x --apparent-size -s "${EXPORT_ROOTFS_DIR}" --exclude var/cache/apt/archives --exclude boot/firmware --block-size=1 | cut -f 1)
 
 # All partition sizes and starts will be aligned to this size
-ALIGN="$((4 * 1024 * 1024))"
+ALIGN="$((8 * 1024 * 1024))"
 # Add this much space to the calculated file size. This allows for
 # some overhead (since actual space usage is usually rounded up to the
 # filesystem block size) and gives some free space on the resulting


### PR DESCRIPTION
Higher-capacity cards (particularly Raspberry Pi 128GB A2) have an 8MB preferred erase size, which is a good indication of the flash block size.

Other large cards may also benefit.