### PR TITLE
Add 'bmp-tools' in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -y update && \
         git vim parted \
         quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools e2fsprogs\
         libarchive-tools libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc \
-        binfmt-support ca-certificates fdisk gpg pigz arch-test \
+        binfmt-support ca-certificates fdisk gpg pigz arch-test bmp-tools \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /pi-gen/


### PR DESCRIPTION
This avoids an error when building with docker.