### PR TITLE
Drop powerstate change hook for rpi-usb-gadget

### DIFF
--- a/stage2/04-cloud-init/files/99_raspberry-pi.cfg
+++ b/stage2/04-cloud-init/files/99_raspberry-pi.cfg
@@ -5,12 +5,6 @@ datasource:
   NoCloud:
     seedfrom: file:///boot/firmware
 
-power_state:
-  delay: now
-  mode: reboot
-  message: Rebooting machine to enable usb gadget mode
-  condition: test -f /etc/modules-load.d/usb-gadget.conf
-
 # Disable SSH host key generation
 # regenerate_ssh_host_keys.service will take care 
 # of it on first boot


### PR DESCRIPTION
Drop this reboot hook because the cloud-init `cc_raspberry_pi` module now includes a reboot trigger.

Related to: https://github.com/canonical/cloud-init/pull/6466

@tdewey-rpi