### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The following environment variables are supported:
 
    Output directory for target system images and NOOBS bundles.
 
- * `DEPLOY_COMPRESSION` (Default: `zip`)
+ * `DEPLOY_COMPRESSION` (Default: `none`)
 
    Set to:
    * `none` to deploy the actual image (`.img`).


### PR DESCRIPTION
Default for DEPLOY_COMPRESSION is incorrect in the README.md file.

From build.sh

`if [ -z "${DEPLOY_COMPRESSION}" ] && [ "${DEPLOY_ZIP:-1}" = "0" ]; then`
`        echo "DEPLOY_ZIP has been deprecated in favor of DEPLOY_COMPRESSION"`
`        echo "Similar behavior to DEPLOY_ZIP=0 can be obtained with DEPLOY_COMPRESSION=none"`
`        echo "Please update your config file"`
`        DEPLOY_COMPRESSION=none`
`fi`
