### PR TITLE
Extend `log` function to show date and time

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -1,5 +1,5 @@
 log (){
-	date +"[%T] $*" | tee -a "${LOG_FILE}"
+	date +"[%Y-%m-%d %T] $*" | tee -a "${LOG_FILE}"
 }
 export -f log
 


### PR DESCRIPTION
I noticed that the timestamps that are used in the build logs don't have a date on them.
This adds a date alongside a timestamp. May be helpful when reviewing build logs on separate days.