### PR TITLE
Set `DISABLE_FIRST_BOOT_USER_RENAME` without requiring `FIRST_USER_PASS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,15 @@ The following environment variables are supported:
 
  * `FIRST_USER_PASS` (Default: unset)
 
-   Password for the first user. If unset, the account is locked.
+   Password for the first user. If unset, the account cannot be logged into with a password.
 
  * `DISABLE_FIRST_BOOT_USER_RENAME` (Default: `0`)
 
-   Disable the renaming of the first user during the first boot. This make it so `FIRST_USER_NAME`
-   stays activated. `FIRST_USER_PASS` must be set for this to work. Please be aware of the implied
-   security risk of defining a default username and password for your devices.
+   Disable the renaming of the first user during the first boot. This makes it so `FIRST_USER_NAME` stays activated.  
+   `FIRST_USER_PASS` must be set in order to log in to the account with a password.  
+   Please be aware of the implied security risk of defining a default username and password for your devices.
+   
+   Alternatively, you may set `ENABLE_SSH`, `PUBKEY_SSH_FIRST_USER` and `PUBKEY_ONLY_SSH` to log in via public key authentication.
 
  * `WPA_COUNTRY` (Default: unset)
 

--- a/build.sh
+++ b/build.sh
@@ -288,12 +288,6 @@ if [[ ! "$FIRST_USER_NAME" =~ ^[a-z][-a-z0-9_]*$ ]]; then
 	exit 1
 fi
 
-if [[ "$DISABLE_FIRST_BOOT_USER_RENAME" == "1" ]] && [ -z "${FIRST_USER_PASS}" ]; then
-	echo "To disable user rename on first boot, FIRST_USER_PASS needs to be set"
-	echo "Not setting FIRST_USER_PASS makes your system vulnerable and open to cyberattacks"
-	exit 1
-fi
-
 if [[ "$DISABLE_FIRST_BOOT_USER_RENAME" == "1" ]]; then
 	echo "User rename on the first boot is disabled"
 	echo "Be advised of the security risks linked to shipping a device with default username/password set."


### PR DESCRIPTION
This change would allow the first boot user to be kept without it requiring a password to log into the account, opening up the the ability to enable SSH and set a public key to use as a method of access into the account, while leaving regular password authentication disabled.

From limited testing, pubkey auth appears to work as long as `ENABLE_SSH`, `PUBKEY_SSH_FIRST_USER` and `PUBKEY_ONLY_SSH` are all set.

Should close #670 