### PR TITLE
Fix logic error in dependencies_check: use variable depfile instead of hardcoded path

### DIFF
--- a/scripts/dependencies_check
+++ b/scripts/dependencies_check
@@ -10,7 +10,7 @@ dependencies_check()
 
 	for depfile in "$@"; do
 		if [[ -e "$depfile" ]]; then
-			deps="$(sed -f "${SCRIPT_DIR}/remove-comments.sed" < "${BASE_DIR}/depends")"
+			deps="$(sed -f "${SCRIPT_DIR}/remove-comments.sed" < "${depfile}")"
 
 		fi
 		for dep in $deps; do


### PR DESCRIPTION
### Fix dependencies_check logic

The dependencies_check function iterates over the arguments ( $@ as $depfile ), but inside the loop, it was hardcoded to read ${BASE_DIR}/depends. This prevented the function from checking any custom dependency files passed as arguments.

This PR changes the redirection to read from < "${depfile}" as intended.