### PR TITLE
Allow to use numeric values to set ENABLE_CLOUD_INIT

### DIFF
--- a/stage2/04-cloud-init/01-run.sh
+++ b/stage2/04-cloud-init/01-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-if [ "${ENABLE_CLOUD_INIT}" != "1" ]; then
+if [[ "${ENABLE_CLOUD_INIT}" != "1" ]]; then
 	log "Skipping cloud-init stage"
 	exit 0
 fi


### PR DESCRIPTION
Allow to use numeric values to set ENABLE_CLOUD_INIT by using double-bracket syntax.

This allows setting

`ENABLE_CLOUD_INIT=1`

in addition to

`ENABLE_CLOUD_INIT="1"`

and ensures consistency with any other config parameters.
