### PR TITLE
Remove loop device suffix when node is not available

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -115,6 +115,7 @@ export -f update_issue
 ensure_next_loopdev() {
 	local loopdev
 	loopdev="$(losetup -f)"
+	loopdev="${loopdev%% *}"
 	loopmaj="$(echo "$loopdev" | sed -E 's/.*[^0-9]*?([0-9]+)$/\1/')"
 	[[ -b "$loopdev" ]] || mknod "$loopdev" b 7 "$loopmaj"
 }


### PR DESCRIPTION
The output of `losetup -f` is not parsed adequately to filter out a possible ` (lost)` suffix which appears in the output when the device has not yet been created by the kernel module.

Expand the variable holding the device path to remove the largest portion of the suffix matching a space plus anything that follows it.