### PR TITLE
Update qemu package from qemu-arm-static to qemu-arm and qemu-user-static to qemu-user

### DIFF
--- a/depends
+++ b/depends
@@ -1,7 +1,7 @@
 quilt
 parted
 realpath:coreutils
-qemu-arm:qemu-user
+qemu-arm:qemu-user-binfmt
 debootstrap
 zerofree
 zip


### PR DESCRIPTION
Since this version, the statically-linked qemu-user binaries from qemu-user-static package has been moved to qemu-user package, effectively making it to be what qemu-user-static has been.

    There's no dynamically-linked qemu-user binaries anymore, in no qemu packages provided by Debian. For more information see [#1079603](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1079603).

    When you upgrade from previous version of qemu-user or qemu-user-static packages, there should be no change in behavour. However, new qemu-user does not provide binary names with "-static" suffix, for example, an interpretator for aarch64 is named qemu-aarch64, not qemu-aarch64-static (the same way it has always been in qemu-user, before this version when it has become static, and it still is). In order to retain compatibility with previous version, qemu-user-static package now ships just the compatibility names (symlinks) with -static suffix.

    Also, qemu-user-static now depends on qemu-user-binfmt package, which just enables binfmt registation of qemu-user binary formats with binfmt-misc kernel subsystem (the formats themselves are shipped by qemu-user now, but are not enabled).

    If you only need qemu in context of in-kernel binfmt-misc subsystem (to run foreign binaries automatically), you need just qemu-user-binfmt package (which also installs qemu-user). In this case, you can safely remove this qemu-user-static package.

    However, if you rely on the naming with -static suffix, you might want to keep qemu-user-static package installed.

    Long term, the intent is to drop this qemu-user-static package, which has become just a compatibility wrapper around real work done now in qemu-user and qemu-user-binfmt packages.