### PR TITLE
Unlock account when SSH public-key is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,10 @@ The following environment variables are supported:
 
   * `PUBKEY_SSH_FIRST_USER` (Default: unset)
 
-   Setting this to a value will make that value the contents of the FIRST_USER_NAME's ~/.ssh/authorized_keys.  Obviously the value should
-   therefore be a valid authorized_keys file.  Note that this does not
-   automatically enable SSH.
+   Setting this to a value will make that value the contents of the FIRST_USER_NAME's
+   ~/.ssh/authorized_keys. Obviously the value should therefore be a valid authorized_keys file.
+   As SSH requires a valid shell this will override the account locking when `FIRST_USER_PASS`
+   is unset. Note that this does not automatically enable SSH.
 
   * `PUBKEY_ONLY_SSH` (Default: `0`)
 

--- a/stage2/01-sys-tweaks/01-run.sh
+++ b/stage2/01-sys-tweaks/01-run.sh
@@ -5,6 +5,12 @@ if [ -n "${PUBKEY_SSH_FIRST_USER}" ]; then
 	echo "${PUBKEY_SSH_FIRST_USER}" >"${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
 	chown 1000:1000 "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
 	chmod 0600 "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
+
+	# SSH login requires user to have a shell, see also stage1/01-sys-tweaks/00-run.sh
+	# build.sh ensures DISABLE_FIRST_BOOT_USER_RENAME == 0 when FIRST_USER_PASS is unset
+	if [ -z "${FIRST_USER_PASS}" ]; then
+		usermod -s /bin/bash "${FIRST_USER_NAME}"
+	fi
 fi
 
 if [ "${PUBKEY_ONLY_SSH}" = "1" ]; then

--- a/stage2/01-sys-tweaks/01-run.sh
+++ b/stage2/01-sys-tweaks/01-run.sh
@@ -5,6 +5,14 @@ if [ -n "${PUBKEY_SSH_FIRST_USER}" ]; then
 	echo "${PUBKEY_SSH_FIRST_USER}" >"${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
 	chown 1000:1000 "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
 	chmod 0600 "${ROOTFS_DIR}"/home/"${FIRST_USER_NAME}"/.ssh/authorized_keys
+
+	# SSH login requires user to have a shell, see also stage1/01-sys-tweaks/00-run.sh
+	# build.sh ensures DISABLE_FIRST_BOOT_USER_RENAME == 0 when FIRST_USER_PASS is unset
+	if [ -z "${FIRST_USER_PASS}" ]; then
+		on_chroot <<- EOF
+			usermod -s /bin/bash "${FIRST_USER_NAME}"
+		EOF
+	fi
 fi
 
 if [ "${PUBKEY_ONLY_SSH}" = "1" ]; then


### PR DESCRIPTION
Commit 4b9cd15c6db9290d5e842503464e1d3429d92f37 breaks public-key SSH configuration.

Make sure first user has a shell when PUBKEY_SSH_FIRST_USER is set.