### PR TITLE
feat(export): add compression progress logging

### DIFF
--- a/export-image/05-finalise/01-run.sh
+++ b/export-image/05-finalise/01-run.sh
@@ -115,6 +115,7 @@ mkdir -p "${DEPLOY_DIR}"
 rm -f "${DEPLOY_DIR}/${ARCHIVE_FILENAME}${IMG_SUFFIX}.*"
 rm -f "${DEPLOY_DIR}/${IMG_FILENAME}${IMG_SUFFIX}.img"
 
+log "Compressing image ($(du -h "${IMG_FILE}" | cut -f1)) using ${DEPLOY_COMPRESSION}, level ${COMPRESSION_LEVEL}. This may take several minutes..."
 case "${DEPLOY_COMPRESSION}" in
 zip)
 	pushd "${STAGE_WORK_DIR}" > /dev/null
@@ -134,6 +135,7 @@ none | *)
 	cp "$IMG_FILE" "$DEPLOY_DIR/"
 ;;
 esac
+log "Compression complete"
 
 if [ -f "${SBOM_FILE}" ]; then
 	xz -c "${SBOM_FILE}" > "$DEPLOY_DIR/$(basename "${SBOM_FILE}").xz"


### PR DESCRIPTION
The build goes silent for several minutes during xz compression of the multi-GB image. Add log messages before and after compression so operators know what's happening.